### PR TITLE
add g4vertex to build order

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -20,6 +20,7 @@ simulation/g4simulation/g4detectors|pinkenburg@bnl.gov
 #cemc needs g4detectors
 simulation/g4simulation/g4cemc|pinkenburg@bnl.gov
 simulation/g4simulation/g4hough|mccumber@bnl.gov
+simulation/g4simulation/g4vertex|mccumber@bnl.gov
 simulation/g4simulation/g4jets|mccumber@bnl.gov
 simulation/g4simulation/g4eval|mccumber@bnl.gov
 simulation/g4simulation/g4dst|mccumber@bnl.gov


### PR DESCRIPTION
This will add the g4vertex module so approval can be merged with the pull request on core software.