### PR TITLE
mlp - added the pmonitor to the nightly rebuild

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -2,6 +2,7 @@
 # modules in CVS
 offline/packages/Half|pinkenburg@bnl.gov
 online_distribution/newbasic|purschke@bnl.gov
+online_distribution/pmonitor|purschke@bnl.gov
 offline/framework/phool|Pinkenburg@bnl.gov
 offline/database/pdbcal/base|Pinkenburg@bnl.gov
 offline/database/pdbcal/pg|Pinkenburg@bnl.gov


### PR DESCRIPTION
This adds the pmonitor project to the nightly rebuild. Note that we first need to satisfy my corresponding pull request in coresoftware so the area is there to begin with. 