### PR TITLE
Pileup simulation and new HepMC input work flow

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -19,7 +19,7 @@ coresoftware/offline/packages/PHField|jhuang@bnl.gov
 #
 # simulations
 #
-coresoftware/simulation/g4simulation/phhepmc|pinkenburg@bnl.gov
+coresoftware/generators/phhepmc|pinkenburg@bnl.gov
 #PHPythia8 needs phhepmc
 coresoftware/generators/PHPythia8|mccumber@bnl.gov
 coresoftware/generators/PHPythia6|nils.feege@stonybrook.edu


### PR DESCRIPTION
Relocate the location for the hepmc lib for the new HepMC input work flow. Works with https://github.com/sPHENIX-Collaboration/coresoftware/pull/364