### PR TITLE
revive tinderbox, put sPHENIX tinderbox output on its own web page

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -144,7 +144,6 @@ $insureCompileFlags = " ";
 
 # An area for reports visible via the web
 $workNFS = $WORKNFS ? $WORKNFS : '/phenix/WWW/offline';
-$tinderbox = $TINDERBOX ? $TINDERBOX : 'phnxtin@rcf2.rhic.bnl.gov';
 $CVSROOT = $CVSROOT ? $CVSROOT :  '/afs/rhic.bnl.gov/phenix/PHENIX_CVS';
 
 $workdir .= "/$opt_version";
@@ -254,15 +253,15 @@ if ($opt_version =~ /play/)
 if ($opt_tinderbox)
   {
     # Let tinderbox know we've started
-    open( MAIL, "|$MAIL $tinderbox" );
-    print MAIL "\n";
-    print MAIL "tinderbox: tree: default\n";
-    print MAIL "tinderbox: builddate: ".$startTime."\n";
-    print MAIL "tinderbox: status: building\n";
-    print MAIL "tinderbox: build: ".$sysname."\n";
-    print MAIL "tinderbox: errorparser: unix\n";
-    print MAIL "tinderbox: END\n";
-    close(MAIL);
+    open(TIND,"| /phenix/WWW/offline/sPHENIX/tinderbox/handlemail.pl /phenix/WWW/offline/sPHENIX/tinderbox");
+    print TIND "\n";
+    print TIND "tinderbox: tree: default\n";
+    print TIND "tinderbox: builddate: ".$startTime."\n";
+    print TIND "tinderbox: status: building\n";
+    print TIND "tinderbox: build: ".$sysname."\n";
+    print TIND "tinderbox: errorparser: unix\n";
+    print TIND "tinderbox: END\n";
+    close(TIND);
   }
 
 # If we're doing a real PHENIX install, then there is an official
@@ -499,7 +498,7 @@ print LOG "===========================================\n";
 		print MAIL "The rebuild crashed in module $m at $date.\n";
 		print MAIL "\"$arg\" failed: $? \n";
 		print MAIL "Please look at the rebuild log, found on: \n";
-		print MAIL "http://www.phenix.bnl.gov/software/tinderbox\n";
+		print MAIL "http://www.phenix.bnl.gov/software/sPHENIX/tinderbox\n";
 		print MAIL "Yours, The Rebuild Daemon \n";
 		close(MAIL);
 	      }
@@ -553,7 +552,7 @@ if ($opt_stage < 3)
 		print MAIL "The rebuild crashed in $m.\n";
 		print MAIL "\"$arg\" failed: $? \n";
 		print MAIL "Please look at the rebuild log: \n";
-		print MAIL "http://www.phenix.bnl.gov/software/tinderbox\n";
+		print MAIL "http://www.phenix.bnl.gov/software/sPHENIX/tinderbox\n";
 		print MAIL "Yours, The Rebuild Daemon\n";
 		close(MAIL);
 	      }
@@ -617,7 +616,7 @@ if ($opt_stage < 4)
 		print MAIL "The rebuild crashed in $m on $date:\n";
 		print MAIL "\"$arg\" reason: $? \n";
 		print MAIL "Please look at the rebuild log, found on: \n";
-		print MAIL "http://www.phenix.bnl.gov/software/tinderbox\n";
+		print MAIL "http://www.phenix.bnl.gov/software/sPHENIX/tinderbox\n";
 		print MAIL "Sincerely, the rebuild daemon \n";
 		close(MAIL);
 	    }
@@ -646,7 +645,7 @@ if ($opt_stage < 4)
 		print MAIL "The rebuild crashed in $m on $date:\n";
 		print MAIL "\"$arg\" reason: $? \n";
 		print MAIL "Please look at the rebuild log, found on: \n";
-		print MAIL "http://www.phenix.bnl.gov/software/tinderbox\n";
+		print MAIL "http://www.phenix.bnl.gov/software/sPHENIX/tinderbox\n";
 		print MAIL "Sincerely, the rebuild daemon \n";
 		close(MAIL);
 	      }
@@ -814,8 +813,8 @@ if ($opt_tinderbox)
     print LOG "tinderbox: build: ".$sysname."\n";
     print LOG "tinderbox: errorparser: unix\n";
     print LOG "tinderbox: END\n";
-    $arg = "$MAIL $tinderbox < $logfile";
-    system($arg);
+    my $cmd = sprintf("cat %s | /phenix/WWW/offline/sPHENIX/tinderbox/handlemail.pl /phenix/WWW/offline/sPHENIX/tinderbox",$logfile);
+    system($cmd);
   }
 
 $rebuildInfo=$OFFLINE_MAIN.'/rebuild.info';
@@ -833,7 +832,7 @@ print INFO " source dir:".$Link{'source'}."\n ";
 print INFO " build dir:".$Link{'build'}."\n ";
 print INFO " install dir:".$Link{'install'}."\n ";
 print INFO " for build logfile see: ".$logfile." or \n ";
-print INFO " http://www.phenix.bnl.gov/software/tinderbox/showbuilds.cgi?tree=default&nocrap=1&maxdate=".$startTime."\n";
+print INFO " http://www.phenix.bnl.gov/software/sPHENIX/tinderbox/showbuilds.cgi?tree=default&nocrap=1&maxdate=".$startTime."\n";
 print INFO " git tag: \n".$opt_gittag."\n";
 print INFO " git command used: \n".$gitcommand."\n";
 %month=('Jan',0,'Feb',1,'Mar',2,'Apr',3,'May',4,'Jun',5,'Jul',6,'Aug',7,'Sep',8,'Oct',9,'Nov',10,'Dec',11);


### PR DESCRIPTION
with the demise of rcf2 the old tinderbox stopped to work. After figuring out how this machinery which has been working unchanged for the last 20 years actually does its job it's back. The output goes now to a separate sPHENIX web page and does not mix with PHENIX anymore.