### PR TITLE
oops coverity host name has also changed

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -985,7 +985,7 @@ sub install_coverity_reports
 	    print LOG "$line";
 	}
 	close(F2);
-	my $covcmd = sprintf("cov-commit-defects --host coverity.rcf.bnl.gov --stream coresoftware --user admin --dir %s",$covdir,$opt_covpasswd);
+	my $covcmd = sprintf("cov-commit-defects --host rldap09.rcf.bnl.gov --stream coresoftware --user admin --dir %s",$covdir,$opt_covpasswd);
 	print LOG "executing $covcmd\n";
 	$covcmd = sprintf("%s --password %s",$covcmd,$opt_covpasswd);
 	open(F2,"$covcmd 2>&1 |");


### PR DESCRIPTION
We have a test server with the new coverity version. That requires the use of another user in the coverity commit command