### PR TITLE
no copying of special packages for play build

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -222,7 +222,7 @@ foreach my $pkg (sort @externalRootPackages)
 
 # temporary until the new versions are okay to use in new build
 # set this to play if you want to use this for the play build
-if ($opt_version =~ /play/) 
+if ($opt_version =~ /playtst/) 
 {
     @externalPackages = ();
     push(@externalPackages,"boost");


### PR DESCRIPTION
the third party packages to be copied are hardcoded right now, the current root6 play build needs the same packages