### PR TITLE
use -l for local builds (insure, coverity) to limit load, unlimited for distcc/ccache

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -32,10 +32,10 @@ for (my $arg = 0; $arg <= $#ARGV; $arg++)
 umask 002;
 # only run 32 parallel build jobs if
 # distcc is in the path, otherwise run 6 (our build machine has 6 cpus)
-my $JOBS = "-j 6";
+my $JOBS = "-l 8.0 -j 6";
 if ($PATH =~ /\/phenix\/u\/phnxbld\/distcc/)
 {
-  $JOBS = "-l 8.0 -j 120";
+  $JOBS = "-j 120";
 }
 $MAIL = '/bin/mail';
 my $SENDMAIL = "/usr/sbin/sendmail -t -v";


### PR DESCRIPTION
I think we shot ourselves in the foot by limiting the load for distcc/ccache builds. An ongoing local build (coverity, insure) could drive the load above 8 and then distcc/ccache builds ran only with 1 thread. Now also localhost is out of the distcc config (.distcc/hosts under the phnxbld account) so these builds will not load the phnxbld machine