### PR TITLE
close logfile after insure reports are analyzed

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -900,14 +900,14 @@ while (<LOG>)
 	$time=$newtime;
       }
   }
-close(LOG);
-close(INFO);
 
 if ($opt_insure && $buildSucceeded==1)
 {
     &check_insure_reports();
 }
 
+close(LOG);
+close(INFO);
 
 # only expire modules if the ana build was successful
 #if ($buildSucceeded==1 && $opt_version =~ /ana/ && $opt_version =~ /insure/)


### PR DESCRIPTION
small bugfix: in case there is a non zero sized insure reports, the parsing went into a closed logfile