### PR TITLE
Fix coverityhtml

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1100,7 +1100,7 @@ sub install_coverity_reports
 			if ($line =~ /Processing 0 errors/)
 			{
 			    $addfile = 0;
-			    print LOG "not adding html file $packages to summary, it is empty"
+			    print LOG "not adding html file $packages to summary, it is empty\n";
 			}
 		    }
 		    close(F2);

--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1093,14 +1093,23 @@ sub install_coverity_reports
 		    my $covcmd = sprintf("cov-format-errors --dir %s --html-output %s",$covdir,$htmldir);
 		    print LOG "$covcmd\n";
 		    open(F2,"$covcmd 2>&1 |");
+                    my $addfile = 1;
 		    while(my $line = <F2>)
 		    {
 			print LOG "$line";
+			if ($line =~ /Processing 0 errors/)
+			{
+			    $addfile = 0;
+			    print LOG "not adding html file $packages to summary, it is empty"
+			}
 		    }
 		    close(F2);
 		    my $packagename = $packages;
 		    $packagename =~  s/\./\//g;
-		    print F1 "<a href=\"$packages\">$packages</a> contact: $contact{$packagename} </br>\n";
+		    if ($addfile > 0)
+		    {
+			print F1 "<a href=\"$packages\">$packages</a> contact: $contact{$packagename} </br>\n";
+		    }
 		}
 		else
 		{


### PR DESCRIPTION
Finally get rid of empty html files. The new coverity version (8.7.1) seems to instrument the code with coverity_ignore before analyzing which suppresses invalid_iterator errors. I guess this is their mechanism to remove false positives (I hope, these are not in our code). But this cannot be parsed from the output of the cov-analyze command which we use to trigger the creation of the html file, only the output of cov-format-errors which generates them gives a hint how many errors there were. Now the output of cov-format-errors is used to determine if the html output should be added to the coverity web output. Now all packages listed on the coverity web page actually do have errors