### PR TITLE
Modified build order to accomodate tracking simulations reorganization

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -20,8 +20,7 @@ coresoftware/offline/packages/PHGeometry|jhuang@bnl.gov
 coresoftware/offline/packages/PHField|jhuang@bnl.gov
 coresoftware/offline/packages/CaloBase|jhuang@bnl.gov
 coresoftware/offline/packages/trackbase|dmcglinchey@lanl.gov
-# mvtx needs trackbase
-coresoftware/offline/packages/mvtx|dmcglinchey@lanl.gov
+coresoftware/offline/packages/trackbase_historic|afrawley@fsu.edu
 #
 # simulations
 # simulations/generator
@@ -37,8 +36,15 @@ coresoftware/simulation/g4simulation/g4decayer|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4gdml|jhuang@bnl.gov
 coresoftware/simulation/g4simulation/g4main|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4detectors|pinkenburg@bnl.gov
-# g4tpc needs g4detectors
+# tracking needs g4detectors
 coresoftware/simulation/g4simulation/g4tpc|pinkenburg@bnl.gov
+coresoftware/simulation/g4simulation/g4mvtx|afrawley@fsu.edu
+coresoftware/simulation/g4simulation/g4intt|afrawley@fsu.edu
+# mvtx needs trackbase, tracking also needs trackbase_historic for now
+# tracking needs g4 modules for geometry classes
+coresoftware/offline/packages/mvtx|dmcglinchey@lanl.gov
+coresoftware/offline/packages/intt|afrawley@fsu.edu
+coresoftware/offline/packages/tpc|afrawley@fsu.edu
 # cemc needs g4detectors
 coresoftware/simulation/g4simulation/g4bbc|pinkenburg@bnl.gov
 # coresoftware/simulation/g4simulation/g4cemc|pinkenburg@bnl.gov


### PR DESCRIPTION
Change to the build order required by the tracking simulations reorganization (PR#529). Tested and debugged using a private build.