### PR TITLE
Fix packageorder

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -589,7 +589,7 @@ if ($opt_stage < 3)
 	print LOG "installing header files and scripts in  $m             \n";
 	print LOG "at $date                                               \n";
 	print LOG "=======================================================\n";
-	$arg = "make install-data";
+	$arg = "make $JOBS install-data";
 
 	if (&doSystemFail($arg))
 	  {

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -18,8 +18,6 @@ coresoftware/generators/flowAfterburner|dave@bnl.gov
 coresoftware/offline/packages/HelixHough|alan.dion@gmail.com
 coresoftware/offline/packages/PHGeometry|jhuang@bnl.gov
 coresoftware/offline/packages/PHField|jhuang@bnl.gov
-coresoftware/offline/packages/trackbase|dmcglinchey@lanl.gov
-coresoftware/offline/packages/trackbase_historic|afrawley@fsu.edu
 #
 # simulations
 # simulations/generator
@@ -35,8 +33,10 @@ coresoftware/simulation/g4simulation/g4decayer|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4gdml|jhuang@bnl.gov
 coresoftware/simulation/g4simulation/g4main|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4detectors|pinkenburg@bnl.gov
-# calobase needs g4celldefs
+# calobase and trackbase need g4celldefs include for root6
 coresoftware/offline/packages/CaloBase|jhuang@bnl.gov
+coresoftware/offline/packages/trackbase|dmcglinchey@lanl.gov
+coresoftware/offline/packages/trackbase_historic|afrawley@fsu.edu
 # tracking needs g4detectors
 coresoftware/simulation/g4simulation/g4tpc|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4mvtx|afrawley@fsu.edu


### PR DESCRIPTION
Under root6.14.00 (our afs version) rootcling cannot find g4celldefs which is not installed at that time, trackbase needs to be build after g4detectors. run make install-data with multiple jobs - under root6 it triggers rootcling to create the pcm files which takes a long time single threaded 