### PR TITLE
move prototype reco to prototype repo

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -35,7 +35,7 @@ my $SENDMAIL = "/usr/sbin/sendmail -t -v";
 my $buildmanager = "pinkenburg\@bnl.gov";
 my $CC = $buildmanager;
 
-my @gitrepos = ("coresoftware", "online_distribution");
+my @gitrepos = ("coresoftware", "online_distribution", "prototype");
 
 my %externalPackages = (
     "boost" => "boost",
@@ -94,10 +94,11 @@ $opt_coverity = 0;
 $opt_lafiles = 0;
 $opt_help = 0;
 $opt_afs = 0;
+$opt_repoowner = 'sPHENIX-Collaboration';
 GetOptions('help', 'stage=i', 'afs',
 	   'version:s', 'tinderbox', 'gittag:s', 'gitbranch:s','source:s',
 	   'phenixinstall','workdir:s','insure','scanbuild',
-	   'coverity','covpasswd:s','notify','64', 'db:i', 'lafiles');
+	   'coverity','covpasswd:s','notify','64', 'db:i', 'lafiles', 'repoowner:s');
 
 if ($opt_help)
   {
@@ -322,7 +323,7 @@ else
     chdir $sourceDir;
     foreach my $repo (@gitrepos)
     {
-	$gitcommand = sprintf("git clone -q https://github.com/sPHENIX-Collaboration/%s.git",$repo);
+	$gitcommand = sprintf("git clone -q https://github.com/%s/%s.git",$opt_repoowner, $repo);
 	print LOG $gitcommand, "\n";
 	goto END if &doSystemFail($gitcommand);
     }

--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1256,6 +1256,7 @@ sub printhelp
     print "--version='string' Prefix for installation area. Default: new\n";
     print "--tinderbox        Send build information to tinderbox.\n";
     print "--gittag='string'  CVS flags for source checkout. \n";
+    print "--repoowner='string'  repository owner (default: sPHENIX--Collaboration). \n";
     print "--phenixinstall    Install in the official AFS area. \n";
     print "--workdir='string'  Set \$workdir (default is /home/\$USER/).\n";
     print "--insure           Rebuild using the Insure++\n";

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -71,9 +71,9 @@ coresoftware/offline/packages/trackreco|yuhw.pku@gmail.com
 coresoftware/offline/packages/CaloReco|jhuang@bnl.gov
 coresoftware/offline/packages/ClusterIso|dvp@bnl.gov
 # Offline software/T1044 prodcution software
-coresoftware/offline/packages/Prototype2|jhuang@bnl.gov
-coresoftware/offline/packages/Prototype3|jhuang@bnl.gov
-coresoftware/offline/packages/Prototype4|jhuang@bnl.gov
+prototype/offline/packages/Prototype2|jhuang@bnl.gov
+prototype/offline/packages/Prototype3|jhuang@bnl.gov
+prototype/offline/packages/Prototype4|jhuang@bnl.gov
 # QA modules that use both simulation and offline libs
 coresoftware/offline/QA/modules|jhuang@bnl.gov
 # the dumping needs all objects and comes last


### PR DESCRIPTION
the prototype reco code (including history) was moved to the prototype repo. The owner of the repo is now an option so builds of private forks can be done without editing the script