### PR TITLE
check if git repo exist to avoid weird errors when users build their own

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1322,7 +1322,7 @@ sub printhelp
     print "--tinderbox        Send build information to tinderbox.\n";
     print "--gittag='string'  git tag for source checkout.\n";
     print "--gitbranch='string' git branch to be used for build\n";
-    print "--repoowner='string' repository owner (default: sPHENIX--Collaboration). \n";
+    print "--repoowner='string' repository owner (default: sPHENIX-Collaboration). \n";
     print "--phenixinstall    Install in the official AFS area. \n";
     print "--workdir='string'  Set \$workdir (default is /home/\$USER/).\n";
     print "--insure           Rebuild using the Insure++\n";

--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -331,6 +331,23 @@ else
 {
     make_path($sourceDir, {mode => 0775}) unless -e $sourceDir;
     chdir $sourceDir;
+    my $statret = 0;
+    $ENV{'GIT_ASKPASS'} = 'true';
+    foreach my $repo (@gitrepos)
+    {
+	$gitcommand = sprintf("git ls-remote https://github.com/%s/%s.git > /dev/null 2>&1",$opt_repoowner, $repo);
+        my $iret = system($gitcommand);
+	if ($iret)
+	{
+	    print LOG "repository https://github.com/$opt_repoowner/$repo.git does not exist\n";
+	}
+        $statret += $iret;
+    }
+    if ($statret)
+    {
+        close(LOG);
+	exit 1;
+    }
     foreach my $repo (@gitrepos)
     {
 	$gitcommand = sprintf("git clone -q https://github.com/%s/%s.git",$opt_repoowner, $repo);
@@ -440,6 +457,8 @@ if ($opt_insure)
       }
    $insureCompileFlags = ' CC="insure gcc -g" CXX="insure g++" CCLD="insure g++"';
   }
+
+# switch OFFLINE_MAIN to new install area and create it
 $oldOfflineMain = $OFFLINE_MAIN;
 $OFFLINE_MAIN = $installDir;
 $ENV{OFFLINE_MAIN} = $installDir;


### PR DESCRIPTION
This PR is for user builds using --repoowner='string'. While we are more or less guaranteed that all repos exist under the sPHENIX-Collaboration, users might not have forks of all required repos. This caused a misleading request to use a password to login to github rather than an error for a non existing repo. This PR checks all repos with git -ls-remote and if one or more are missing quits with a list of missing repos