### PR TITLE
Add /opt/sphenix/utils

### DIFF
--- a/utils/singularity/copy_to_target_area.pl
+++ b/utils/singularity/copy_to_target_area.pl
@@ -12,11 +12,12 @@ use File::Basename;
 my $opt_all = 0;
 my $opt_singularity = 0;
 my $opt_optsphenix = 0;
+my $opt_optutils = 0;
 my $opt_offline = 0;
 my $opt_help = 0;
 my $opt_test = 0;
 my $opt_version = 'new';
-GetOptions('all' => \$opt_all, 'help' => \$opt_help, 'offline' => \$opt_offline, 'opt' => \$opt_optsphenix, 'singularity' => \$opt_singularity, 'test' => \$opt_test, 'version:s' => \$opt_version);
+GetOptions('all' => \$opt_all, 'help' => \$opt_help, 'offline' => \$opt_offline, 'opt' => \$opt_optsphenix, 'utils' => \$opt_optutils, 'singularity' => \$opt_singularity, 'test' => \$opt_test, 'version:s' => \$opt_version);
 
 if ($#ARGV < 0 || $opt_help>0)
 {
@@ -28,11 +29,12 @@ if ($#ARGV < 0 || $opt_help>0)
     print "--opt          : create and copy opt area tar ball\n";
     print "--singularity  : copy container\n";
     print "--test         : dryrun, print commands but do not execute them\n";
+    print "--utils        : create and copy utils area tar ball\n";
     exit 1;
 }
-if (!$opt_all && !$opt_singularity && !$opt_optsphenix && !$opt_offline)
+if (!$opt_all && !$opt_singularity && !$opt_optsphenix && !$opt_offline && !$opt_optutils)
 {
-    print "no tarball selected, select --all for all, --offline for offline, --opt for opt\n";
+    print "no tarball selected, select --all for all, --offline for offline, --opt for opt --utils for utils\n";
     exit 1;
 }
 
@@ -53,9 +55,11 @@ my $sourcedir = sprintf("/cvmfs/sphenix.sdcc.bnl.gov");
 my $singularity_container = sprintf("%s/singularity/rhic_sl7_ext.simg",$sourcedir);
 my $opt_dir = sprintf("/opt/sphenix/core");
 my $opt_tmp_tarfile = sprintf("/tmp/opt.tar");
+my $utils_tmp_tarfile = sprintf("/tmp/utils.tar");
 my @opt_dir_list = ("/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/bin",
                     "/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/etc",
                     "/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/include",
+                    "/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/lib",
                     "/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/share",
 		    "/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/stow",
 		    "/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/core/lhapdf",
@@ -143,6 +147,40 @@ if ($opt_optsphenix > 0 || $opt_all > 0)
 	}
     }
 }
+if ($opt_optutils > 0 || $opt_all > 0)
+{
+    my $opttargetdir = sprintf("%s/%s",$targetdir,$opt_version);
+    if (! $opt_test)
+    {
+	mkpath($opttargetdir);
+    }
+    my $utilsdir = sprintf("/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/opt/sphenix/utils");
+    my $tarcmd = sprintf("tar  -cf %s %s",$utils_tmp_tarfile,$utilsdir);
+    print "tarcmd: $tarcmd\n";
+    if (! $opt_test)
+    {
+	system($tarcmd);
+    }
+    my $zipcmd = sprintf("bzip2 %s",$utils_tmp_tarfile);
+    if (! $opt_test)
+    {
+	system($zipcmd);
+    }
+    my $zipfile = sprintf("%s.bz2",$utils_tmp_tarfile);
+    print "moving $zipfile to $opttargetdir\n";
+    if (-f $zipfile)
+    {
+	move($zipfile, $opttargetdir);
+    }
+    else
+    {
+	if (! $opt_test)
+	{
+	    print "could not find $zipfile\n";
+	    exit 1;
+	}
+    }
+}
 
 if ($opt_offline > 0 || $opt_all > 0)
 {
@@ -153,6 +191,13 @@ if ($opt_offline > 0 || $opt_all > 0)
     }
     my $offline_symlink = sprintf("/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/release/release_%s/%s",$opt_version,$opt_version);
     my $tarcmd = sprintf("tar -cf %s %s",$offline_tmp_tarfile,$offline_symlink);
+    print "executing $tarcmd\n";
+    if (! $opt_test)
+    {
+	system($tarcmd);
+    }
+    $offline_symlink = sprintf("/cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/release/%s",$opt_version);
+    $tarcmd = sprintf("tar -cf %s %s",$offline_tmp_tarfile,$offline_symlink);
     print "executing $tarcmd\n";
     if (! $opt_test)
     {

--- a/utils/singularity/create_index_html.pl
+++ b/utils/singularity/create_index_html.pl
@@ -14,6 +14,7 @@ $rootversion{"root6"} = "Root6";
 my %tarball = ();
 $tarball{"opt.tar.bz2"} = "coresoftware tarball";
 $tarball{"offline_main.tar.bz2"} = "OFFLINE_MAIN tarball";
+$tarball{"utils.tar.bz2"} = "utilities tarball";
 
 my $opt_help = 0;
 


### PR DESCRIPTION
This PR adds the /opt/sphenix/utils tarball. It is not needed to run reconstruction but it contains development utilities (cppcheck, valgrind,...) which are useful to have