### PR TITLE
Revert "Trackbase implementation"

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -38,15 +38,15 @@ coresoftware/simulation/g4simulation/g4detectors|pinkenburg@bnl.gov
 coresoftware/offline/packages/CaloBase|jhuang@bnl.gov
 coresoftware/offline/packages/trackbase|dmcglinchey@lanl.gov
 coresoftware/offline/packages/trackbase_historic|afrawley@fsu.edu
-# mvtx needs trackbase, tracking also needs trackbase_historic for now
-# tracking needs g4 modules for geometry classes
-coresoftware/offline/packages/intt|afrawley@fsu.edu
-coresoftware/offline/packages/tpc|afrawley@fsu.edu
-coresoftware/offline/packages/mvtx|dmcglinchey@lanl.gov
 # tracking needs g4detectors
 coresoftware/simulation/g4simulation/g4tpc|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4mvtx|afrawley@fsu.edu
 coresoftware/simulation/g4simulation/g4intt|afrawley@fsu.edu
+# mvtx needs trackbase, tracking also needs trackbase_historic for now
+# tracking needs g4 modules for geometry classes
+coresoftware/offline/packages/mvtx|dmcglinchey@lanl.gov
+coresoftware/offline/packages/intt|afrawley@fsu.edu
+coresoftware/offline/packages/tpc|afrawley@fsu.edu
 # cemc needs g4detectors
 coresoftware/simulation/g4simulation/g4bbc|pinkenburg@bnl.gov
 # coresoftware/simulation/g4simulation/g4cemc|pinkenburg@bnl.gov


### PR DESCRIPTION
Hmm.... Have to reverts sPHENIX-Collaboration/utilities#59  The INTT lib still depends on g4intt in the current coresoftware prior to Tony's tracking reorganization: https://github.com/sPHENIX-Collaboration/coresoftware/pull/614 

Currently it breaks the build: https://web.racf.bnl.gov/jenkins-sphenix/job/sPHENIX/job/sPHENIX_CoreSoftware_MasterBranch/168/ 