### PR TITLE
g4dst needs to be build last

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -61,7 +61,6 @@ coresoftware/simulation/g4simulation/g4vertex|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4jets|dvp@bnl.gov
 coresoftware/offline/packages/jetbackground|dvp@bnl.gov
 # simulations/Geant4/ convenience library to load all necessary libs to read DST content
-coresoftware/simulation/g4simulation/g4dst|pinkenburg@bnl.gov
 # simulations/Geant4/ evals
 coresoftware/simulation/g4simulation/g4eval|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4trackfastsim|jhuang@bnl.gov
@@ -80,3 +79,6 @@ prototype/offline/packages/Prototype4|jhuang@bnl.gov
 coresoftware/offline/QA/modules|jhuang@bnl.gov
 # the dumping needs all objects and comes last
 coresoftware/offline/packages/NodeDump|pinkenburg@bnl.gov
+# this is the convenience library which loads all libraries needed for reading
+# DSTs, please leave it at the end of the package list
+coresoftware/simulation/g4simulation/g4dst|pinkenburg@bnl.gov


### PR DESCRIPTION
the PR moves the build of g4dst to the end. It is just a convenience library which loads all libraries from our DSTs so you only have to load this one to read DSTs without problems