### PR TITLE
getlogin returns nothing on jenkins, use jenkins as username

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1023,7 +1023,7 @@ if ($opt_insure && $buildSucceeded==1)
     &check_insure_reports();
 }
 # save the git tags in DB only for the build account
-my $username = getlogin;
+my $username = getlogin || "jenkins";
 if ($username eq "phnxbld")
 {
   SaveGitTagsToDB();


### PR DESCRIPTION
This PR fixes an error in jenkins. getlogin does not seem to return anything on the jenkins machine, this sets the username to "jenkins" if getlogin does not return anything. This is not critical, action is only taken if the account is phnxbld in which case the git tag of the build is stored in a DB