### PR TITLE
build clang inside singularity container which mounts modified include

### DIFF
--- a/utils/rebuild/clang_build_singularity.csh
+++ b/utils/rebuild/clang_build_singularity.csh
@@ -1,0 +1,10 @@
+#!/bin/csh -f
+
+# create dumb shell script to call build.pl inside container
+echo "#\!/bin/csh -f" > clang_build.csh
+echo "source /opt/sphenix/core/bin/sphenix_setup.csh -n clang" >> clang_build.csh
+echo "build.pl --version='clang' --clang --phenixinstall" >> clang_build.csh
+chmod +x clang_build.csh
+
+set dir=$PWD
+singularity exec -B /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/patches/hashtable_policy.h:/usr/include/c++/4.8.2/bits/hashtable_policy.h -B /home /cvmfs/sphenix.sdcc.bnl.gov/singularity/rhic_sl7_ext.simg $dir/clang_build.csh


### PR DESCRIPTION
This PR adds a small shell script to call the build with clang. clang needs a modified include file /usr/include/c++/4.8.2/bits/hashtable_policy.h which is mounted from our cvmfs repo. The binaries do not need this include to run (also gcc is fine with that modification but we do not want to push this out for all users of rcf).