### PR TITLE
remove build of g4hough

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -56,7 +56,7 @@ coresoftware/offline/packages/trigger|dvp@bnl.gov
 coresoftware/offline/packages/PHGenFitPkg/GenFitExp|yuhw.pku@gmail.com
 coresoftware/offline/packages/PHGenFitPkg/PHGenFit|yuhw.pku@gmail.com
 # g4hough needs genfit
-coresoftware/simulation/g4simulation/g4hough|yuhw.pku@gmail.com
+#coresoftware/simulation/g4simulation/g4hough|yuhw.pku@gmail.com
 coresoftware/simulation/g4simulation/g4vertex|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4jets|dvp@bnl.gov
 coresoftware/offline/packages/jetbackground|dvp@bnl.gov

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -28,7 +28,6 @@ coresoftware/generators/PHPythia6|nils.feege@stonybrook.edu
 #PHSartre needs phhepmc
 coresoftware/generators/PHSartre|lajoie@iastate.edu
 # simulations/Geant4
-# coresoftware/simulation/g4simulation/g4field|pinkenburg@bnl.gov -- removed since https://github.com/sPHENIX-Collaboration/coresoftware/pull/349
 coresoftware/simulation/g4simulation/EICPhysicsList|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4decayer|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4gdml|jhuang@bnl.gov
@@ -55,8 +54,6 @@ coresoftware/offline/packages/trigger|dvp@bnl.gov
 # genfit stuff
 coresoftware/offline/packages/PHGenFitPkg/GenFitExp|yuhw.pku@gmail.com
 coresoftware/offline/packages/PHGenFitPkg/PHGenFit|yuhw.pku@gmail.com
-# g4hough needs genfit
-#coresoftware/simulation/g4simulation/g4hough|yuhw.pku@gmail.com
 coresoftware/simulation/g4simulation/g4vertex|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4jets|dvp@bnl.gov
 coresoftware/offline/packages/jetbackground|dvp@bnl.gov


### PR DESCRIPTION
This PR removes the g4hough from the package list and the ancient commented out phfield