### PR TITLE
Add KFParticle to packages copied to OFFLINE_MAIN (and with it Vc)

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -56,11 +56,13 @@ my %externalPackages = (
     "pythia8" => "pythia8",
     "rapidjson" => "rapidjson",
     "rave" => "rave",
-    "TAUOLA" => "TAUOLA"
+    "TAUOLA" => "TAUOLA",
+    "Vc" => "Vc"
     );
 my $externalPackagesDir = "$OPT_SPHENIX";
 my %externalRootPackages = (
     "eic-smear" => "eic-smear",
+    "KFParticle" => "KFParticle",
     "pythiaeRHIC" => "pythiaeRHIC",
     "sartre-1.20" => "sartre-1.20"
     );


### PR DESCRIPTION
This PR adds KFParticle (which depends on the root version) and Vc needed by KFParticel to OFFLINE_MAIN. KFParticle unfortunately dumps all its header files into the include directory without package path, so all this gets dumped to OFFLINE_MAIN/include. We should change that at some point