### PR TITLE
adjust load limit in make to number of cores

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -140,10 +140,12 @@ if ( $opt_db && $opt_version !~ /pro/)
     $getpackages->finish();
 }
 
-# only run 32 parallel build jobs if
-# distcc is in the path, otherwise run 6 (our build machine has 6 cpus)
+# only run 120 parallel build jobs if distcc is in the path (it is not
+# right now), otherwise run numjobs = number of cores
+# the -l adjusts for load, if the load is number of cores all cores are busy
+# to first order (disk load goes into the load as well)
 my $numcores  = do { local @ARGV='/proc/cpuinfo'; grep /^processor\s+:/, <>;};
-my $JOBS = sprintf("-l 8.0 -j %d", $numcores);
+my $JOBS = sprintf("-l %d -j %d", $numcores, $numcores);
 if ($PATH =~ /\/phenix\/u\/phnxbld\/distcc/)
 {
   $JOBS = "-j 120";


### PR DESCRIPTION
This PR sets the -l in make to the number of cores. I did some reading what the load actually means, it is basically the number of busy cores though the disk activity goes into this number as well. That means up to a load of the number of cores there are idle cores which should be used. The previous 8 was definitely too low for our new build machines