### PR TITLE
gcc 8.3 play build uses g4 10.06, needs other clhep version

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -239,8 +239,16 @@ print LOG "$cmdline\n\n";
 # set this to play if you want to use this for the play build
 if ($opt_version =~ /play/) 
 {
-    $externalPackages{"rave"} = "rave-0.6.25_clhep-2.4.1.0";
-    $externalPackages{"CLHEP"} = "clhep-2.4.1.0";
+    if ($opt_sysname =~ /gcc-8.3/)
+    {
+	$externalPackages{"rave"} = "rave-0.6.25_clhep-2.4.1.3";
+	$externalPackages{"CLHEP"} = "clhep-2.4.1.3";
+    }
+    else
+    {
+	$externalPackages{"rave"} = "rave-0.6.25_clhep-2.4.1.0";
+	$externalPackages{"CLHEP"} = "clhep-2.4.1.0";
+    }
 }
 elsif ($opt_version =~ /old/) # build with previous versions 
 {


### PR DESCRIPTION
This PR prepares the build script for the play build under gcc 8.3 using the newest G4 version (10.06) which does not build with gcc 4.8.2