### PR TITLE
return -1 on failure

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -989,7 +989,7 @@ else
 
 END:{
   $buildSucceeded==1 && ($buildStatus='success', last END);
-  $buildSucceeded==0 && ($buildStatus='busted', last END);
+  $buildSucceeded==0 && ($buildStatus='busted', exit(-1));
 }
 
 # save the latest commit id of the checkouts


### PR DESCRIPTION
This PR adds a -1 return value if the build fails. That should make Jenkins's job easier to spot build failures