### PR TITLE
use new gsl lib for play build

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -255,6 +255,7 @@ if ($opt_version =~ /play/)
     {
 	$externalPackages{"rave"} = "rave-0.6.25_clhep-2.4.1.0";
 	$externalPackages{"CLHEP"} = "clhep-2.4.1.0";
+	$externalPackages{"gsl"} = "gsl-2.6";
     }
 }
 elsif ($opt_version =~ /old/) # build with previous versions 


### PR DESCRIPTION
This PR copies the newest gsl version (2.6) to OFFLINE_MAIN for the play build