### PR TITLE
Finalize scan build

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1326,7 +1326,7 @@ sub install_scanbuild_reports
     remove_tree($installdir);
     make_path($installdir, {mode => 0775});
 # copy all reports to WWW accessible place
-    system("cp -rp $scanlogdir/* $installdir");
+    system("rsync -a $scanlogdir/ $installdir");
 # make all files group readable (actual build errors are owner read only)
     system("find $installdir -type f -exec chmod 664 {} \\;");
 # scan through directories, extract package name and create html index file
@@ -1356,19 +1356,26 @@ sub install_scanbuild_reports
     my %mailinglist;
     my $indexfile = sprintf("%s/index.html",$installdir);
     open(F,">$indexfile");
-    for my $packages (sort keys %packets)
+    if (!keys %packets) # whoa - no scan build warnings!!!!
     {
-	my $hrefentry = basename($packets{$packages});
-        my $packagename = $packages;
-	$packagename =~  s/\./\//g;
-	print F "<a href=\"$hrefentry\">$packages</a> contact: $contact{$packagename} </br>\n";
-	if (exists $contact{$packagename})
+	print F "<H1>Congratulations - No Scan Build Warnings</H1>\n:";
+    }
+    else
+    {
+	for my $packages (sort keys %packets)
 	{
-	    $mailinglist{$packagename} = "https://www.phenix.bnl.gov/WWW/p/draft/phnxbld/sphenix/scan-build/scan/$hrefentry";
-	}
-	else
-	{
-	    print LOG "Could not locate contact for package $packagename\n";
+	    my $hrefentry = basename($packets{$packages});
+	    my $packagename = $packages;
+	    $packagename =~  s/\./\//g;
+	    print F "<a href=\"$hrefentry\">$packages</a> contact: $contact{$packagename} </br>\n";
+	    if (exists $contact{$packagename})
+	    {
+		$mailinglist{$packagename} = "https://www.phenix.bnl.gov/WWW/p/draft/phnxbld/sphenix/scan-build/scan/$hrefentry";
+	    }
+	    else
+	    {
+		print LOG "Could not locate contact for package $packagename\n";
+	    }
 	}
     }
     close(F);

--- a/utils/rebuild/scan-build_singularity.csh
+++ b/utils/rebuild/scan-build_singularity.csh
@@ -1,0 +1,10 @@
+#!/bin/csh -f
+
+# create dumb shell script to call build.pl inside container
+echo "#\!/bin/csh -f" > scan-build.csh
+echo "source /opt/sphenix/core/bin/sphenix_setup.csh -n" >> scan-build.csh
+echo "build.pl --scanbuild --phenixinstall --version='scan'" >> scan-build.csh
+chmod +x scan-build.csh
+
+set dir=$PWD
+singularity exec -B /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/patches/hashtable_policy.h:/usr/include/c++/4.8.2/bits/hashtable_policy.h -B /home -B /gpfs -B /sphenix -B /direct/phenix+WWW -B /phenix /cvmfs/sphenix.sdcc.bnl.gov/singularity/rhic_sl7_ext.simg $dir/scan-build.csh


### PR DESCRIPTION
This PR writes a correct index.html if there are no scan-build errors (highly unlikely) and adds a script to run it inside a container for gcc 4.8.2 bc the compiler bug which prevents the usage of clang