### PR TITLE
Add different external packages for test version

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -260,6 +260,10 @@ if ($opt_version =~ /play/)
 	$externalPackages{"gsl"} = "gsl-2.6";
     }
 }
+elsif ($opt_version =~ /test/) 
+{
+      $externalPackages{"gsl"} = "gsl-2.6";
+}
 elsif ($opt_version =~ /old/) # build with previous versions 
 {
     $externalPackages{"boost"} = "boost-1.67.0";


### PR DESCRIPTION
This PR just adds using gsl-2.6 instead of the default for test builds