### PR TITLE
Add eic

### DIFF
--- a/utils/rebuild/eic-packages.txt
+++ b/utils/rebuild/eic-packages.txt
@@ -1,0 +1,83 @@
+# This list gives the packages we build in the order in which they are build
+acts-framework|osbornjd@ornl.gov
+fun4all_coresoftware/offline/packages/Half|pinkenburg@bnl.gov
+online_distribution/newbasic|purschke@bnl.gov
+online_distribution/pmonitor|purschke@bnl.gov
+fun4all_coresoftware/offline/framework/phool|Pinkenburg@bnl.gov
+fun4all_coresoftware/offline/framework/phoolraw|Pinkenburg@bnl.gov
+fun4all_coresoftware/offline/database/pdbcal/base|Pinkenburg@bnl.gov
+fun4all_coresoftware/offline/database/pdbcal/pg|Pinkenburg@bnl.gov
+fun4all_coresoftware/offline/database/PHParameter|Pinkenburg@bnl.gov
+fun4all_coresoftware/offline/packages/vararray|Pinkenburg@bnl.gov
+fun4all_coresoftware/offline/framework/frog|irina@bnl.gov
+fun4all_coresoftware/offline/framework/ffaobjects|Pinkenburg@bnl.gov
+fun4all_coresoftware/offline/framework/fun4all|pinkenburg@bnl.gov
+fun4all_coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
+fun4all_coresoftware/generators/JEWEL|kunnawalkamraghav@gmail.com
+fun4all_coresoftware/generators/hijing|dave@bnl.gov
+fun4all_coresoftware/generators/sHijing|dave@bnl.gov
+fun4all_coresoftware/generators/flowAfterburner|dave@bnl.gov
+fun4all_coresoftware/offline/packages/HelixHough|alan.dion@gmail.com
+fun4all_coresoftware/offline/packages/PHGeometry|jhuang@bnl.gov
+fun4all_coresoftware/offline/packages/PHField|jhuang@bnl.gov
+#
+# simulations
+# simulations/generator
+fun4all_coresoftware/generators/phhepmc|pinkenburg@bnl.gov
+#PHPythia8 needs phhepmc
+fun4all_coresoftware/generators/PHPythia8|dvp@bnl.gov
+fun4all_coresoftware/generators/PHPythia6|nils.feege@stonybrook.edu
+#PHSartre needs phhepmc
+fun4all_coresoftware/generators/PHSartre|lajoie@iastate.edu
+# simulations/Geant4
+fun4all_coresoftware/simulation/g4simulation/EICPhysicsList|pinkenburg@bnl.gov
+fun4all_coresoftware/simulation/g4simulation/g4decayer|pinkenburg@bnl.gov
+fun4all_coresoftware/simulation/g4simulation/g4gdml|jhuang@bnl.gov
+fun4all_coresoftware/simulation/g4simulation/g4main|pinkenburg@bnl.gov
+fun4all_coresoftware/simulation/g4simulation/g4detectors|pinkenburg@bnl.gov
+# calobase and trackbase need g4celldefs include for root6
+fun4all_coresoftware/offline/packages/CaloBase|jhuang@bnl.gov
+fun4all_coresoftware/offline/packages/trackbase|dmcglinchey@lanl.gov
+fun4all_coresoftware/offline/packages/trackbase_historic|afrawley@fsu.edu
+# tracking needs g4 detectors for geometry classes
+# mvtx needs trackbase, tracking also needs trackbase_historic for now
+fun4all_coresoftware/offline/packages/mvtx|dmcglinchey@lanl.gov
+fun4all_coresoftware/offline/packages/intt|afrawley@fsu.edu
+fun4all_coresoftware/offline/packages/tpc|afrawley@fsu.edu
+# g4tpc, g4mvtx and g4intt need tpc, mvtx and intt
+fun4all_coresoftware/simulation/g4simulation/g4tpc|pinkenburg@bnl.gov
+fun4all_coresoftware/simulation/g4simulation/g4mvtx|afrawley@fsu.edu
+fun4all_coresoftware/simulation/g4simulation/g4intt|afrawley@fsu.edu
+# cemc needs g4detectors
+fun4all_coresoftware/simulation/g4simulation/g4bbc|pinkenburg@bnl.gov
+# fun4all_coresoftware/simulation/g4simulation/g4cemc|pinkenburg@bnl.gov
+fun4all_coresoftware/simulation/g4simulation/g4calo|jhuang@bnl.gov
+fun4all_coresoftware/offline/packages/trigger|dvp@bnl.gov
+# genfit stuff
+fun4all_coresoftware/offline/packages/PHGenFitPkg/GenFitExp|yuhw.pku@gmail.com
+fun4all_coresoftware/offline/packages/PHGenFitPkg/PHGenFit|yuhw.pku@gmail.com
+fun4all_coresoftware/simulation/g4simulation/g4vertex|pinkenburg@bnl.gov
+fun4all_coresoftware/simulation/g4simulation/g4jets|dvp@bnl.gov
+fun4all_coresoftware/offline/packages/jetbackground|dvp@bnl.gov
+# simulations/Geant4/ evals
+fun4all_coresoftware/simulation/g4simulation/g4eval|pinkenburg@bnl.gov
+fun4all_coresoftware/simulation/g4simulation/g4trackfastsim|jhuang@bnl.gov
+fun4all_coresoftware/simulation/g4simulation/g4histos|pinkenburg@bnl.gov
+#fun4all_coresoftware/simulation/g4simulation/g4picoDst|lxue4@gsu.edu
+# Offline tracking software
+fun4all_coresoftware/offline/packages/trackreco|yuhw.pku@gmail.com
+fun4all_coresoftware/offline/packages/tpccalib|hugo.pereira-da-costa@cea.fr
+# Offline calorimeter software
+fun4all_coresoftware/offline/packages/CaloReco|jhuang@bnl.gov
+fun4all_coresoftware/offline/packages/ClusterIso|dvp@bnl.gov
+# QA modules that use both simulation and offline libs
+fun4all_coresoftware/offline/QA/modules|jhuang@bnl.gov
+# the dumping needs all objects and comes last
+fun4all_coresoftware/offline/packages/NodeDump|pinkenburg@bnl.gov
+# this is the convenience library which loads all libraries needed for reading
+# DSTs, please leave it at the end of the package list
+fun4all_coresoftware/simulation/g4simulation/g4dst|pinkenburg@bnl.gov
+fun4all_g4jleic/source|pinkenburg@bnl.gov
+g4lblvtx/source|pinkenburg@bnl.gov
+qinhua/source|pinkenburg@bnl.gov
+g4hakanvtx/source|pinkenburg@bnl.gov

--- a/utils/rebuild/eic-repositories.txt
+++ b/utils/rebuild/eic-repositories.txt
@@ -1,0 +1,7 @@
+acts-framework
+fun4all_coresoftware
+online_distribution
+fun4all_g4jleic
+g4lblvtx
+qinhua
+g4hakanvtx


### PR DESCRIPTION
This PR adds a --eic flag to deal with eic specific changes which would otherwise make the sPHENIX life more difficult. It changes the calibrations repo name to fun4all_calibrations and uses eic-repositories.txt and eic-packages.txt for the eic repos and eic packages. It adds a --cvmfsvol option - defaulting to 'sphenix.sdcc.bnl.gov' so it can be installed to other cvmfs volumes. Tested with sPHENIX builds and eic builds.