### PR TITLE
build acts, not acts-framework

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -1,5 +1,5 @@
 # This list gives the packages we build in the order in which they are build
-acts-framework|osbornjd@ornl.gov
+acts|osbornjd@ornl.gov
 coresoftware/offline/packages/Half|pinkenburg@bnl.gov
 online_distribution/newbasic|purschke@bnl.gov
 online_distribution/pmonitor|purschke@bnl.gov

--- a/utils/rebuild/repositories.txt
+++ b/utils/rebuild/repositories.txt
@@ -1,4 +1,4 @@
-acts-framework
+acts
 calibrations
 coresoftware
 online_distribution


### PR DESCRIPTION
This PR replaces acts-framework by acts in the package and repositories