### PR TITLE
check out new acts repo instead of acts-framework

### DIFF
--- a/utils/rebuild/eic-packages.txt
+++ b/utils/rebuild/eic-packages.txt
@@ -1,5 +1,5 @@
 # This list gives the packages we build in the order in which they are build
-acts-framework|osbornjd@ornl.gov
+fun4all_acts|osbornjd@ornl.gov
 fun4all_coresoftware/offline/packages/Half|pinkenburg@bnl.gov
 online_distribution/newbasic|purschke@bnl.gov
 online_distribution/pmonitor|purschke@bnl.gov

--- a/utils/rebuild/eic-repositories.txt
+++ b/utils/rebuild/eic-repositories.txt
@@ -1,5 +1,5 @@
-acts-framework
 calibrations
+fun4all_acts
 fun4all_coresoftware
 fun4all_eicdetectors
 fun4all_g4jleic


### PR DESCRIPTION
This PR just updates the eic build with the new acts repo instead of acts-framework