### PR TITLE
include-what-you-use needs path to clang system includes

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -798,7 +798,7 @@ if ($opt_stage < 4)
             {
                 if ($opt_includecheck)
                 {
-                    $arg = "make -k CXX=/opt/sphenix/utils/bin/include-what-you-use "
+                    $arg = "make -k CXX='/opt/sphenix/utils/bin/include-what-you-use -I/opt/sphenix/utils/lib/clang/9.0.1/include ' "
                 }
                 else
                 {


### PR DESCRIPTION
This PR fixes the build with include-what-you-use. With the clang upgrade to 9.0.1 clang uses its own system headers and it needs a -I/opt/sphenix/utils/lib/clang/9.0.1/include for include-what-you-use to find them