### PR TITLE
configure sources using clang

### DIFF
--- a/utils/rebuild/clang_includecheck_singularity.csh
+++ b/utils/rebuild/clang_includecheck_singularity.csh
@@ -3,7 +3,7 @@
 # create dumb shell script to call build.pl inside container
 echo "#\!/bin/csh -f" > clang_includecheck.csh
 echo "source /opt/sphenix/core/bin/sphenix_setup.csh -n clang" >> clang_includecheck.csh
-echo "build.pl --includecheck --version='includecheck'" >> clang_includecheck.csh
+echo "build.pl --includecheck --clang --version='includecheck'" >> clang_includecheck.csh
 chmod +x clang_includecheck.csh
 
 set dir=$PWD


### PR DESCRIPTION
This PR is a small fix. include-what-you-use is based on clang and therefore the sources need to be configured using clang. So far they are configured using gcc which leads to different suppressions of warnings which then prevent include-what-you-use from compiling those sources