### PR TITLE
strip crlf from hostname

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -182,7 +182,8 @@ $JOBS = sprintf("-j %d",$numcores) if $opt_insure;
 $MAXDEPTH = 4 if $opt_insure;
 
 $workdir = $opt_workdir ? $opt_workdir : '/home/'. $USER . '/' . $collaboration;
-my $myhost = `hostname -s`;
+my $myhost = `hostname`;
+chomp $myhost;
 $startTime = time;
 $sysname = $USER.'@'.$myhost.'#'.$Config{osname}.':'.$opt_version;
 $compileFlags = ($sysname =~ m/linux/) ? ' INSTALL="/usr/bin/install -D -p" install_sh="/usr/bin/install -D -p"' : "";


### PR DESCRIPTION
The latest change used $myhost=`hostname` so this works under bash where $HOST is not defined. Sadly this adds a crlf to $myhost which messed you the string which tells tinderbox what kind of build it is dealing with. A simple chomp $myhost takes care of that 