### PR TITLE
Ignore missing package

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -631,6 +631,11 @@ print LOG "===========================================\n";
 	foreach my $m (@package)
 	{
 	    my $sdir = realpath($sourceDir)."/".$m;
+	    if (! -d $sdir)
+	    {
+		print LOG "$sdir not found, skipping\n";
+		next;
+	    }
 	    my $bdir = realpath($buildDir)."/".$m;
 	    make_path($bdir, {verbose=>1, mode => 0775});
 	    chdir $bdir;
@@ -726,6 +731,11 @@ if ($opt_stage < 3)
           next;
         }
         $sdir = realpath($sourceDir)."/".$m;
+	if (! -d $sdir)
+	{
+	    print LOG "$sdir not found, skipping\n";
+	    next;
+	}
         $bdir = realpath($buildDir)."/".$m;
         chdir $bdir;
         chomp ($date = `date`);
@@ -775,7 +785,12 @@ if ($opt_stage < 4)
                   $covbuild = sprintf("%s --dir %s/covtmp/%s",$covcommonbuild,$workdir,$m);
               }
           }
-        $sdir = realpath($sourceDir)."/".$m;
+	  $sdir = realpath($sourceDir)."/".$m;
+	  if (! -d $sdir)
+	  {
+	      print LOG "$sdir not found, skipping\n";
+	      next;
+	  }
         $bdir = realpath($buildDir)."/".$m;
         chdir $bdir;
         chomp ($date = `date`);

--- a/utils/rebuild/eic-packages.txt
+++ b/utils/rebuild/eic-packages.txt
@@ -20,6 +20,7 @@ fun4all_coresoftware/generators/flowAfterburner|dave@bnl.gov
 fun4all_coresoftware/offline/packages/HelixHough|alan.dion@gmail.com
 fun4all_coresoftware/offline/packages/PHGeometry|jhuang@bnl.gov
 fun4all_coresoftware/offline/packages/PHField|jhuang@bnl.gov
+fun4all_coresoftware/offline/packages/PHTpcTracker|arkhipkin@bnl.gov
 #
 # simulations
 # simulations/generator

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -20,6 +20,7 @@ coresoftware/generators/flowAfterburner|dave@bnl.gov
 coresoftware/offline/packages/HelixHough|alan.dion@gmail.com
 coresoftware/offline/packages/PHGeometry|jhuang@bnl.gov
 coresoftware/offline/packages/PHField|jhuang@bnl.gov
+coresoftware/offline/packages/PHTpcTracker|arkhipkin@bnl.gov
 #
 # simulations
 # simulations/generator


### PR DESCRIPTION
This PR enables the build to ignore missing packages. This means we can add new packages to our build (so jenkins can run over it) without crashing every other build while the new package is being evaluated.
Also adding Dmitry's PHTpcTracker to the build