### PR TITLE
fix tinderbox when build is busted

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -41,7 +41,7 @@ for (my $arg = 0; $arg <= $#ARGV; $arg++)
 
 umask 002;
 $MAIL = '/bin/mail';
-my $SENDMAIL = "/usr/sbin/sendmail -t -v";
+my $SENDMAIL = "/usr/sbin/sendmail -t";
 my $buildmanager = "pinkenburg\@bnl.gov";
 my $CC = $buildmanager;
 
@@ -1047,7 +1047,7 @@ else
 
 END:{
   $buildSucceeded==1 && ($buildStatus='success', last END);
-  $buildSucceeded==0 && ($buildStatus='busted', exit(-1));
+  $buildSucceeded==0 && ($buildStatus='busted', last END);
 }
 
 # save the latest commit id of the checkouts


### PR DESCRIPTION
the build script aborted on failure before informing tinderbox which also prevented the logs from getting into tinderbox. This PR fixes this behavior (it also un-chatters sendmail so I do not get any mails from the cron jobs with the mail log)