### PR TITLE
use relative symlink for build version (e.g. new -> new.4)

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -944,8 +944,10 @@ INSTALLONLY:
 $buildSucceeded = 1;
 
 # OK, installation done; move symlink over
+print LOG "removing old installation symlink $inst\n";
 unlink $inst if (-e $inst);
-symlink $linkTarget, $inst;
+print LOG "creating symlink  $inst -> " .  basename($linkTarget) . ", full target: $linkTarget\n";
+symlink basename($linkTarget), $inst;
 # install for scan and coverity build means copying reports which are not in afs
 if ($opt_phenixinstall && !$opt_scanbuild && !$opt_coverity)
 {


### PR DESCRIPTION
This PR changes the version symlinks to relative links. So far e.g. new pointed to /cvmfs/sphenix.sdcc.bnl.gov/x8664_sl7/release/release_new/new.3. That is no problem for running with cvmfs but local builds with a mounted cvmfs filesystem got confused and pointed you back to cvmfs. This PR now creates new -> new.3 so this stays within the same filesystem