### PR TITLE
Fix maintainers

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -695,7 +695,7 @@ print LOG "===========================================\n";
 		    print MAIL "The rebuild crashed in module $m at $date.\n";
 		    print MAIL "\"$arg\" failed: $? \n";
 		    print MAIL "Please look at the rebuild log, found on: \n";
-		    print MAIL "http://www.phenix.bnl.gov/software/",$collaboration,"/tinderbox\n";
+		    print MAIL "https://phenix-intra.sdcc.bnl.gov/software/",$collaboration,"/tinderbox\n";
 		    print MAIL "Yours, The Rebuild Daemon \n";
 		    close(MAIL);
 		}
@@ -758,7 +758,7 @@ if ($opt_stage < 3)
                 print MAIL "The rebuild crashed in $m.\n";
                 print MAIL "\"$arg\" failed: $? \n";
                 print MAIL "Please look at the rebuild log: \n";
-                print MAIL "http://www.phenix.bnl.gov/software/",$collaboration,"/tinderbox\n";
+                print MAIL "https://phenix-intra.sdcc.bnl.gov/software/",$collaboration,"/tinderbox\n";
                 print MAIL "Yours, The Rebuild Daemon\n";
                 close(MAIL);
               }
@@ -835,7 +835,7 @@ if ($opt_stage < 4)
                 print MAIL "The rebuild crashed in $m on $date:\n";
                 print MAIL "\"$arg\" reason: $? \n";
                 print MAIL "Please look at the rebuild log, found on: \n";
-                print MAIL "http://www.phenix.bnl.gov/software/",$collaboration,"/tinderbox\n";
+                print MAIL "https://phenix-intra.sdcc.bnl.gov/software/",$collaboration,"/tinderbox\n";
                 print MAIL "Sincerely, the rebuild daemon \n";
                 close(MAIL);
             }
@@ -871,7 +871,7 @@ if ($opt_stage < 4)
                 print MAIL "The rebuild crashed in $m on $date:\n";
                 print MAIL "\"$arg\" reason: $? \n";
                 print MAIL "Please look at the rebuild log, found on: \n";
-                print MAIL "http://www.phenix.bnl.gov/software/",$collaboration,"/tinderbox\n";
+                print MAIL "https://phenix-intra.sdcc.bnl.gov/software/",$collaboration,"/tinderbox\n";
                 print MAIL "Sincerely, the rebuild daemon \n";
                 close(MAIL);
               }
@@ -1119,7 +1119,7 @@ print INFO " source dir:".$sourceDir."\n ";
 print INFO " build dir:".$buildDir."\n ";
 print INFO " install dir:".$installDir."\n ";
 print INFO " for build logfile see: ".$logfile." or \n ";
-print INFO " http://www.phenix.bnl.gov/software/",$collaboration,"/tinderbox/showbuilds.cgi?tree=default&nocrap=1&maxdate=".$startTime."\n";
+print INFO " https://phenix-intra.sdcc.bnl.gov/software/",$collaboration,"/tinderbox/showbuilds.cgi?tree=default&nocrap=1&maxdate=".$startTime."\n";
 if ($opt_gittag ne '')
 {
   print INFO " git tag: ".$opt_gittag."\n";
@@ -1272,7 +1272,7 @@ sub check_expiration_date
         print MAIL "Hello,\n";
         print MAIL "Your module $mods[0] has reached is expiration date on $date.\n";
         print MAIL "You can reenable it on the web under:\n";
-        print MAIL "https://www.phenix.bnl.gov/WWW/p/draft/anatrain/TrainV2/trainbuild/modifymodule.html\n";
+        print MAIL "https://phenix-intra.sdcc.bnl.gov/WWW/p/draft/anatrain/TrainV2/trainbuild/modifymodule.html\n";
         print MAIL "Yours, The Rebuild Daemon \n\n";
         close(MAIL);
     }
@@ -1444,7 +1444,7 @@ sub install_scanbuild_reports
             print F "<a href=\"$hrefentry\">$packages</a> contact: $contact{$packagename} </br>\n";
             if (exists $contact{$packagename})
             {
-                $mailinglist{$packagename} = sprintf("https://www.phenix.bnl.gov/WWW/p/draft/phnxbld/%s/scan-build/scan/%s",$collaboration,$hrefentry);
+                $mailinglist{$packagename} = sprintf("https://phenix-intra.sdcc.bnl.gov/WWW/p/draft/phnxbld/%s/scan-build/scan/%s",$collaboration,$hrefentry);
             }
             else
             {
@@ -1478,9 +1478,9 @@ sub install_scanbuild_reports
             print MAIL "The report is under\n\n";
             print MAIL "$mailinglist{$package}\n\n";
             print MAIL "All reports are available under\n\n";
-            print MAIL "https://www.phenix.bnl.gov/WWW/p/draft/phnxbld/",$collaboration,"/scan-build/scan\n\n";
+            print MAIL "https://phenix-intra.sdcc.bnl.gov/WWW/p/draft/phnxbld/",$collaboration,"/scan-build/scan\n\n";
             print MAIL "instructions how to run scan-build yourself are in our wiki\n\n";
-            print MAIL "https://www.phenix.bnl.gov/WWW/offline/wikioff/index.php/Scan-build\n\n";
+            print MAIL "https://wiki.bnl.gov/sPHENIX/index.php/Tools#scan_build\n\n";
             print MAIL "Please look at the report and fix the issues found\n";
             print MAIL "Sincerely yours, The Rebuild Daemon \n\n";
             close(MAIL);

--- a/utils/rebuild/eic-packages.txt
+++ b/utils/rebuild/eic-packages.txt
@@ -3,21 +3,21 @@ fun4all_acts|osbornjd@ornl.gov
 fun4all_coresoftware/offline/packages/Half|pinkenburg@bnl.gov
 online_distribution/newbasic|purschke@bnl.gov
 online_distribution/pmonitor|purschke@bnl.gov
-fun4all_coresoftware/offline/framework/phool|Pinkenburg@bnl.gov
-fun4all_coresoftware/offline/framework/phoolraw|Pinkenburg@bnl.gov
-fun4all_coresoftware/offline/database/pdbcal/base|Pinkenburg@bnl.gov
-fun4all_coresoftware/offline/database/pdbcal/pg|Pinkenburg@bnl.gov
-fun4all_coresoftware/offline/database/PHParameter|Pinkenburg@bnl.gov
-fun4all_coresoftware/offline/packages/vararray|Pinkenburg@bnl.gov
-fun4all_coresoftware/offline/framework/frog|irina@bnl.gov
-fun4all_coresoftware/offline/framework/ffaobjects|Pinkenburg@bnl.gov
+fun4all_coresoftware/offline/framework/phool|pinkenburg@bnl.gov
+fun4all_coresoftware/offline/framework/phoolraw|pinkenburg@bnl.gov
+fun4all_coresoftware/offline/database/pdbcal/base|pinkenburg@bnl.gov
+fun4all_coresoftware/offline/database/pdbcal/pg|pinkenburg@bnl.gov
+fun4all_coresoftware/offline/database/PHParameter|pinkenburg@bnl.gov
+fun4all_coresoftware/offline/packages/vararray|pinkenburg@bnl.gov
+fun4all_coresoftware/offline/framework/frog|pinkenburg@bnl.gov
+fun4all_coresoftware/offline/framework/ffaobjects|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/framework/fun4all|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
 fun4all_coresoftware/generators/JEWEL|kunnawalkamraghav@gmail.com
 fun4all_coresoftware/generators/hijing|dave@bnl.gov
 fun4all_coresoftware/generators/sHijing|dave@bnl.gov
 fun4all_coresoftware/generators/flowAfterburner|dave@bnl.gov
-fun4all_coresoftware/offline/packages/HelixHough|alan.dion@gmail.com
+fun4all_coresoftware/offline/packages/HelixHough|afrawley@fsu.edu
 fun4all_coresoftware/offline/packages/PHGeometry|jhuang@bnl.gov
 fun4all_coresoftware/offline/packages/PHField|jhuang@bnl.gov
 #
@@ -26,7 +26,7 @@ fun4all_coresoftware/offline/packages/PHField|jhuang@bnl.gov
 fun4all_coresoftware/generators/phhepmc|pinkenburg@bnl.gov
 #PHPythia8 needs phhepmc
 fun4all_coresoftware/generators/PHPythia8|dvp@bnl.gov
-fun4all_coresoftware/generators/PHPythia6|nils.feege@stonybrook.edu
+fun4all_coresoftware/generators/PHPythia6|pinkenburg@bnl.gov
 #PHSartre needs phhepmc
 fun4all_coresoftware/generators/PHSartre|lajoie@iastate.edu
 # simulations/Geant4
@@ -37,11 +37,11 @@ fun4all_coresoftware/simulation/g4simulation/g4main|pinkenburg@bnl.gov
 fun4all_coresoftware/simulation/g4simulation/g4detectors|pinkenburg@bnl.gov
 # calobase and trackbase need g4celldefs include for root6
 fun4all_coresoftware/offline/packages/CaloBase|jhuang@bnl.gov
-fun4all_coresoftware/offline/packages/trackbase|dmcglinchey@lanl.gov
+fun4all_coresoftware/offline/packages/trackbase|afrawley@fsu.edu
 fun4all_coresoftware/offline/packages/trackbase_historic|afrawley@fsu.edu
 # tracking needs g4 detectors for geometry classes
 # mvtx needs trackbase, tracking also needs trackbase_historic for now
-fun4all_coresoftware/offline/packages/mvtx|dmcglinchey@lanl.gov
+fun4all_coresoftware/offline/packages/mvtx|ycmorales@rcf.rhic.bnl.gov
 fun4all_coresoftware/offline/packages/intt|afrawley@fsu.edu
 fun4all_coresoftware/offline/packages/tpc|afrawley@fsu.edu
 fun4all_coresoftware/offline/packages/micromegas|hugo.pereira-da-costa@cea.fr
@@ -56,8 +56,8 @@ fun4all_coresoftware/simulation/g4simulation/g4bbc|pinkenburg@bnl.gov
 fun4all_coresoftware/simulation/g4simulation/g4calo|jhuang@bnl.gov
 fun4all_coresoftware/offline/packages/trigger|dvp@bnl.gov
 # genfit stuff
-fun4all_coresoftware/offline/packages/PHGenFitPkg/GenFitExp|yuhw.pku@gmail.com
-fun4all_coresoftware/offline/packages/PHGenFitPkg/PHGenFit|yuhw.pku@gmail.com
+fun4all_coresoftware/offline/packages/PHGenFitPkg/GenFitExp|pinkenburg@bnl.gov
+fun4all_coresoftware/offline/packages/PHGenFitPkg/PHGenFit|pinkenburg@bnl.gov
 fun4all_coresoftware/simulation/g4simulation/g4vertex|pinkenburg@bnl.gov
 fun4all_coresoftware/simulation/g4simulation/g4jets|dvp@bnl.gov
 fun4all_coresoftware/offline/packages/jetbackground|dvp@bnl.gov
@@ -65,9 +65,8 @@ fun4all_coresoftware/offline/packages/jetbackground|dvp@bnl.gov
 fun4all_coresoftware/simulation/g4simulation/g4eval|pinkenburg@bnl.gov
 fun4all_coresoftware/simulation/g4simulation/g4trackfastsim|jhuang@bnl.gov
 fun4all_coresoftware/simulation/g4simulation/g4histos|pinkenburg@bnl.gov
-#fun4all_coresoftware/simulation/g4simulation/g4picoDst|lxue4@gsu.edu
 # Offline tracking software
-fun4all_coresoftware/offline/packages/trackreco|yuhw.pku@gmail.com
+fun4all_coresoftware/offline/packages/trackreco|osbornjd@ornl.gov
 # PHTpcTracker needs libtrack_reco
 fun4all_coresoftware/offline/packages/PHTpcTracker|arkhipkin@bnl.gov
 fun4all_coresoftware/offline/packages/tpccalib|hugo.pereira-da-costa@cea.fr

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -3,21 +3,21 @@ acts|osbornjd@ornl.gov
 coresoftware/offline/packages/Half|pinkenburg@bnl.gov
 online_distribution/newbasic|purschke@bnl.gov
 online_distribution/pmonitor|purschke@bnl.gov
-coresoftware/offline/framework/phool|Pinkenburg@bnl.gov
-coresoftware/offline/framework/phoolraw|Pinkenburg@bnl.gov
-coresoftware/offline/database/pdbcal/base|Pinkenburg@bnl.gov
-coresoftware/offline/database/pdbcal/pg|Pinkenburg@bnl.gov
-coresoftware/offline/database/PHParameter|Pinkenburg@bnl.gov
-coresoftware/offline/packages/vararray|Pinkenburg@bnl.gov
-coresoftware/offline/framework/frog|irina@bnl.gov
-coresoftware/offline/framework/ffaobjects|Pinkenburg@bnl.gov
+coresoftware/offline/framework/phool|pinkenburg@bnl.gov
+coresoftware/offline/framework/phoolraw|pinkenburg@bnl.gov
+coresoftware/offline/database/pdbcal/base|pinkenburg@bnl.gov
+coresoftware/offline/database/pdbcal/pg|pinkenburg@bnl.gov
+coresoftware/offline/database/PHParameter|pinkenburg@bnl.gov
+coresoftware/offline/packages/vararray|pinkenburg@bnl.gov
+coresoftware/offline/framework/frog|pinkenburg@bnl.gov
+coresoftware/offline/framework/ffaobjects|pinkenburg@bnl.gov
 coresoftware/offline/framework/fun4all|pinkenburg@bnl.gov
 coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
 coresoftware/generators/JEWEL|kunnawalkamraghav@gmail.com
 coresoftware/generators/hijing|dave@bnl.gov
 coresoftware/generators/sHijing|dave@bnl.gov
 coresoftware/generators/flowAfterburner|dave@bnl.gov
-coresoftware/offline/packages/HelixHough|alan.dion@gmail.com
+coresoftware/offline/packages/HelixHough|afrawley@fsu.edu
 coresoftware/offline/packages/PHGeometry|jhuang@bnl.gov
 coresoftware/offline/packages/PHField|jhuang@bnl.gov
 #
@@ -26,7 +26,7 @@ coresoftware/offline/packages/PHField|jhuang@bnl.gov
 coresoftware/generators/phhepmc|pinkenburg@bnl.gov
 #PHPythia8 needs phhepmc
 coresoftware/generators/PHPythia8|dvp@bnl.gov
-coresoftware/generators/PHPythia6|nils.feege@stonybrook.edu
+coresoftware/generators/PHPythia6|pinkenburg@bnl.gov
 #PHSartre needs phhepmc
 coresoftware/generators/PHSartre|lajoie@iastate.edu
 # simulations/Geant4
@@ -37,11 +37,11 @@ coresoftware/simulation/g4simulation/g4main|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4detectors|pinkenburg@bnl.gov
 # calobase and trackbase need g4celldefs include for root6
 coresoftware/offline/packages/CaloBase|jhuang@bnl.gov
-coresoftware/offline/packages/trackbase|dmcglinchey@lanl.gov
+coresoftware/offline/packages/trackbase|afrawley@fsu.edu
 coresoftware/offline/packages/trackbase_historic|afrawley@fsu.edu
 # tracking needs g4 detectors for geometry classes
 # mvtx needs trackbase, tracking also needs trackbase_historic for now
-coresoftware/offline/packages/mvtx|dmcglinchey@lanl.gov
+coresoftware/offline/packages/mvtx|ycmorales@rcf.rhic.bnl.gov
 coresoftware/offline/packages/intt|afrawley@fsu.edu
 coresoftware/offline/packages/tpc|afrawley@fsu.edu
 coresoftware/offline/packages/micromegas|hugo.pereira-da-costa@cea.fr
@@ -56,8 +56,8 @@ coresoftware/simulation/g4simulation/g4bbc|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4calo|jhuang@bnl.gov
 coresoftware/offline/packages/trigger|dvp@bnl.gov
 # genfit stuff
-coresoftware/offline/packages/PHGenFitPkg/GenFitExp|yuhw.pku@gmail.com
-coresoftware/offline/packages/PHGenFitPkg/PHGenFit|yuhw.pku@gmail.com
+coresoftware/offline/packages/PHGenFitPkg/GenFitExp|pinkenburg@bnl.gov
+coresoftware/offline/packages/PHGenFitPkg/PHGenFit|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4vertex|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4jets|dvp@bnl.gov
 coresoftware/offline/packages/jetbackground|dvp@bnl.gov
@@ -65,9 +65,8 @@ coresoftware/offline/packages/jetbackground|dvp@bnl.gov
 coresoftware/simulation/g4simulation/g4eval|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4trackfastsim|jhuang@bnl.gov
 coresoftware/simulation/g4simulation/g4histos|pinkenburg@bnl.gov
-#coresoftware/simulation/g4simulation/g4picoDst|lxue4@gsu.edu
 # Offline tracking software
-coresoftware/offline/packages/trackreco|yuhw.pku@gmail.com
+coresoftware/offline/packages/trackreco|osbornjd@ornl.gov
 # PHTpcTracker needs libtrack_reco
 coresoftware/offline/packages/PHTpcTracker|arkhipkin@bnl.gov
 coresoftware/offline/packages/tpccalib|hugo.pereira-da-costa@cea.fr


### PR DESCRIPTION
Finally update package maintainers (a few of them have left years ago), replace links pointing to www.phenix.bnl.gov to phenix internal webserver phenix-intra.sdcc.bnl.gov 