### PR TITLE
build acts with ccache if CCACHE_DIR is set

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -172,10 +172,6 @@ if ( $opt_db && $opt_version !~ /pro/)
 # to first order (disk load goes into the load as well)
 my $numcores  = do { local @ARGV='/proc/cpuinfo'; grep /^processor\s+:/, <>;};
 my $JOBS = sprintf("-l %d -j %d", $numcores, $numcores);
-if ($PATH =~ /\/phenix\/u\/phnxbld\/distcc/)
-{
-  $JOBS = "-j 120";
-}
 
 my $MAXDEPTH = ($opt_version =~ m/pro/ || $opt_version =~ /ana/ ) ? 9999999 : 4;
 $opt_version .= '+insure' if $opt_insure;
@@ -1568,8 +1564,14 @@ sub CreateCmakeCommand
         {
             $cmakecmd = sprintf("%s -DCMAKE_BUILD_TYPE=Debug",$cmakecmd);
         }
+	if (defined $CCACHE_DIR)
+	{
+	    my $ccompiler = `which g++`;
+	    chomp $ccompiler;
+	    $cmakecmd = sprintf("%s -DCMAKE_CXX_COMPILER=%s",$cmakecmd,$ccompiler);
+	}
         $cmakecmd = sprintf("%s %s",$cmakecmd, $cmakesourcedir);
-        return $cmakecmd;
+	return $cmakecmd;
     }
     print LOG "CreateCmakeCommand not implemented for $packagename\n";
     die;


### PR DESCRIPTION
cmake needs some more convincing to use ccache - it refuses to use the path for the compiler. It needs to be called with -DCMAKE_CXX_COMPILER=`which g++`. This is now used when CCACHE_DIR is set. Setting -DCMAKE_CXX_COMPILER doesn't hurt if ccache is not enabled but I'd rather leave the default sane 