### PR TITLE
add coresoftware/generators/FermiMotionAfterburner to build

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -17,6 +17,7 @@ coresoftware/generators/JEWEL|kunnawalkamraghav@gmail.com
 coresoftware/generators/hijing|dave@bnl.gov
 coresoftware/generators/sHijing|dave@bnl.gov
 coresoftware/generators/flowAfterburner|dave@bnl.gov
+coresoftware/generators/FermiMotionAfterburner|sl4859@columbia.edu
 coresoftware/offline/packages/HelixHough|afrawley@fsu.edu
 coresoftware/offline/packages/PHGeometry|jhuang@bnl.gov
 coresoftware/offline/packages/PHField|jhuang@bnl.gov


### PR DESCRIPTION
This PR adds the FermiMotionAfterburner to the build (so jenkins actually compiles it)