### PR TITLE
do not copy ccache-3.6 to tar ball

### DIFF
--- a/utils/singularity/utils_no_tar.list
+++ b/utils/singularity/utils_no_tar.list
@@ -2,6 +2,7 @@ stow/llv*
 stow/include-what-you-use*
 stow/Python*
 stow/ccache-3.4.2*
+stow/ccache-3.6*
 stow/cmake-3.11.1*
 stow/cmake-3.15.1*
 stow/cppcheck-1.83*


### PR DESCRIPTION
add outdated package to list of packages which are not copied to offline tar ball