### PR TITLE
Compile ACTS with insure for --insure

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1574,7 +1574,23 @@ sub CreateCmakeCommand
         {
             $cmakecmd = sprintf("%s -DCMAKE_BUILD_TYPE=Debug",$cmakecmd);
         }
-	if (defined $CCACHE_DIR)
+        if ($opt_insure)
+	{
+# cmake is not able to digest 'insure g++' as compiler, so we create a little
+# shell script with insure g++ -g and use it as compiler
+# the shell script ends up in the acts build dir so we just leave it there
+	    my $insurecompiler = `which insure`;
+	    chomp $insurecompiler;
+	    my $runscript = "run_gpp.sh";
+	    open(F2,">$runscript");
+            my $runcmd = sprintf("%s g++ -g \$*",$insurecompiler);
+            print F2 "$runcmd\n";
+	    close(F2);
+	    chmod 0755, $runscript;
+	    print LOG "using insure $insurecompiler\n";
+	    $cmakecmd = sprintf("%s -DCMAKE_CXX_COMPILER=%s -DCMAKE_BUILD_TYPE=Debug",$cmakecmd,$runscript);
+	}
+	elsif (defined $CCACHE_DIR)
 	{
 	    my $cxxcompiler = `which g++`;
 	    chomp $cxxcompiler;


### PR DESCRIPTION
This PR adds compilation with insure to ACTS. cmake needs a bit of convincing to actually do this but a temporary shell script with the command line does the trick