### PR TITLE
move ffamodules behind phhepmc to catch sim info

### DIFF
--- a/utils/rebuild/eic-packages.txt
+++ b/utils/rebuild/eic-packages.txt
@@ -13,7 +13,6 @@ fun4all_coresoftware/offline/framework/frog|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/framework/ffaobjects|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/framework/fun4all|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
-fun4all_coresoftware/offline/framework/ffamodules|pinkenburg@bnl.gov
 fun4all_coresoftware/generators/JEWEL|kunnawalkamraghav@gmail.com
 fun4all_coresoftware/generators/hijing|dave@bnl.gov
 fun4all_coresoftware/generators/sHijing|dave@bnl.gov
@@ -30,6 +29,8 @@ fun4all_coresoftware/generators/PHPythia8|dvp@bnl.gov
 fun4all_coresoftware/generators/PHPythia6|pinkenburg@bnl.gov
 #PHSartre needs phhepmc
 fun4all_coresoftware/generators/PHSartre|lajoie@iastate.edu
+# we want generator values in the event header
+coresoftware/offline/framework/ffamodules|pinkenburg@bnl.gov
 # simulations/Geant4
 fun4all_coresoftware/simulation/g4simulation/EICPhysicsList|pinkenburg@bnl.gov
 fun4all_coresoftware/simulation/g4simulation/g4decayer|pinkenburg@bnl.gov

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -13,7 +13,6 @@ coresoftware/offline/framework/frog|pinkenburg@bnl.gov
 coresoftware/offline/framework/ffaobjects|pinkenburg@bnl.gov
 coresoftware/offline/framework/fun4all|pinkenburg@bnl.gov
 coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
-coresoftware/offline/framework/ffamodules|pinkenburg@bnl.gov
 coresoftware/generators/JEWEL|kunnawalkamraghav@gmail.com
 coresoftware/generators/hijing|dave@bnl.gov
 coresoftware/generators/sHijing|dave@bnl.gov
@@ -32,6 +31,8 @@ coresoftware/generators/PHPythia8|dvp@bnl.gov
 coresoftware/generators/PHPythia6|pinkenburg@bnl.gov
 #PHSartre needs phhepmc
 coresoftware/generators/PHSartre|lajoie@iastate.edu
+# we want generator values in the event header
+coresoftware/offline/framework/ffamodules|pinkenburg@bnl.gov
 # simulations/Geant4
 coresoftware/simulation/g4simulation/EICPhysicsList|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4decayer|pinkenburg@bnl.gov


### PR DESCRIPTION
This PR moves the ffamodules. The new header reco needs to catch the simulation information which is read in by phhepmc (or created by the event generators)