### PR TITLE
add FermiMotionAfterburner to eic-packages.txt

### DIFF
--- a/utils/rebuild/eic-packages.txt
+++ b/utils/rebuild/eic-packages.txt
@@ -24,6 +24,8 @@ fun4all_coresoftware/offline/packages/PHField|jhuang@bnl.gov
 # simulations
 # simulations/generator
 fun4all_coresoftware/generators/phhepmc|pinkenburg@bnl.gov
+# fermi motion uses phhepmc
+coresoftware/generators/FermiMotionAfterburner|sl4859@columbia.edu
 #PHPythia8 needs phhepmc
 fun4all_coresoftware/generators/PHPythia8|dvp@bnl.gov
 fun4all_coresoftware/generators/PHPythia6|pinkenburg@bnl.gov


### PR DESCRIPTION
This PR fixes a build problem for the eic (needs the fermi motion to load G4_Input.C)