### PR TITLE
upgrade IWYU to clang 11.1.0

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -824,7 +824,7 @@ if ($opt_stage < 4)
             {
                 if ($opt_includecheck)
                 {
-                    $arg = "make -k CXX='/opt/sphenix/utils/bin/include-what-you-use -I/opt/sphenix/utils/lib/clang/9.0.1/include ' "
+                    $arg = "make -k CXX='include-what-you-use -I/opt/sphenix/utils/lib/clang/11.1.0/include ' "
                 }
                 else
                 {


### PR DESCRIPTION
include what you use needs the path to the corresponding clang installation for the include files. I guess I could extract it from the clang version. Maybe next time. At least include what you use now works in the gcc 8.3 environment