### PR TITLE
remove raw data related packages temporary from build

### DIFF
--- a/utils/rebuild/ecce-packages.txt
+++ b/utils/rebuild/ecce-packages.txt
@@ -4,7 +4,7 @@ coresoftware/offline/packages/Half|pinkenburg@bnl.gov
 online_distribution/newbasic|purschke@bnl.gov
 online_distribution/pmonitor|purschke@bnl.gov
 coresoftware/offline/framework/phool|pinkenburg@bnl.gov
-coresoftware/offline/framework/phoolraw|pinkenburg@bnl.gov
+#coresoftware/offline/framework/phoolraw|pinkenburg@bnl.gov
 coresoftware/offline/database/pdbcal/base|pinkenburg@bnl.gov
 coresoftware/offline/database/pdbcal/pg|pinkenburg@bnl.gov
 coresoftware/offline/database/PHParameter|pinkenburg@bnl.gov
@@ -12,7 +12,7 @@ coresoftware/offline/packages/vararray|pinkenburg@bnl.gov
 coresoftware/offline/framework/frog|pinkenburg@bnl.gov
 coresoftware/offline/framework/ffaobjects|pinkenburg@bnl.gov
 coresoftware/offline/framework/fun4all|pinkenburg@bnl.gov
-coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
+#coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
 coresoftware/generators/JEWEL|kunnawalkamraghav@gmail.com
 coresoftware/generators/hijing|dave@bnl.gov
 coresoftware/generators/sHijing|dave@bnl.gov

--- a/utils/rebuild/eic-packages.txt
+++ b/utils/rebuild/eic-packages.txt
@@ -4,7 +4,7 @@ fun4all_coresoftware/offline/packages/Half|pinkenburg@bnl.gov
 online_distribution/newbasic|purschke@bnl.gov
 online_distribution/pmonitor|purschke@bnl.gov
 fun4all_coresoftware/offline/framework/phool|pinkenburg@bnl.gov
-fun4all_coresoftware/offline/framework/phoolraw|pinkenburg@bnl.gov
+#fun4all_coresoftware/offline/framework/phoolraw|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/database/pdbcal/base|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/database/pdbcal/pg|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/database/PHParameter|pinkenburg@bnl.gov
@@ -12,7 +12,7 @@ fun4all_coresoftware/offline/packages/vararray|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/framework/frog|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/framework/ffaobjects|pinkenburg@bnl.gov
 fun4all_coresoftware/offline/framework/fun4all|pinkenburg@bnl.gov
-fun4all_coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
+#fun4all_coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
 fun4all_coresoftware/generators/JEWEL|kunnawalkamraghav@gmail.com
 fun4all_coresoftware/generators/hijing|dave@bnl.gov
 fun4all_coresoftware/generators/sHijing|dave@bnl.gov

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -4,7 +4,7 @@ coresoftware/offline/packages/Half|pinkenburg@bnl.gov
 online_distribution/newbasic|purschke@bnl.gov
 online_distribution/pmonitor|purschke@bnl.gov
 coresoftware/offline/framework/phool|pinkenburg@bnl.gov
-coresoftware/offline/framework/phoolraw|pinkenburg@bnl.gov
+#coresoftware/offline/framework/phoolraw|pinkenburg@bnl.gov
 coresoftware/offline/database/pdbcal/base|pinkenburg@bnl.gov
 coresoftware/offline/database/pdbcal/pg|pinkenburg@bnl.gov
 coresoftware/offline/database/PHParameter|pinkenburg@bnl.gov
@@ -12,7 +12,7 @@ coresoftware/offline/packages/vararray|pinkenburg@bnl.gov
 coresoftware/offline/framework/frog|pinkenburg@bnl.gov
 coresoftware/offline/framework/ffaobjects|pinkenburg@bnl.gov
 coresoftware/offline/framework/fun4all|pinkenburg@bnl.gov
-coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
+#coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
 coresoftware/generators/JEWEL|kunnawalkamraghav@gmail.com
 coresoftware/generators/hijing|dave@bnl.gov
 coresoftware/generators/sHijing|dave@bnl.gov


### PR DESCRIPTION
This PR removes the raw data related packages phoolraw and fun4allraw temporarily from the build. These packages will be fixed in a subsequent PR. This way all crashed jenkins jobs for existing PRs should just go through