### PR TITLE
add fun4all_eicmacros which now contains the eic macros

### DIFF
--- a/utils/rebuild/ecce-repositories.txt
+++ b/utils/rebuild/ecce-repositories.txt
@@ -1,6 +1,7 @@
 acts
 calibrations
 coresoftware
+fun4all_eicmacros
 online_distribution
 macros
 utilities


### PR DESCRIPTION
This PR adds the ecce fork of the eic macros to the build