### PR TITLE
move g4 sim packages under simulation/g4simulation

### DIFF
--- a/utils/rebuild/ecce-packages.txt
+++ b/utils/rebuild/ecce-packages.txt
@@ -89,7 +89,7 @@ coresoftware/offline/packages/NodeDump|pinkenburg@bnl.gov
 # this is the convenience library which loads all libraries needed for reading
 # DSTs, please leave it at the end of the package list
 coresoftware/simulation/g4simulation/g4dst|pinkenburg@bnl.gov
-fun4all_eicdetectors/g4drcalo|osbornjd@ornl.gov
-fun4all_eicdetectors/g4eiccalos|osbornjd@ornl.gov
-fun4all_eicdetectors/g4mrich|osbornjd@ornl.gov
-fun4all_eicdetectors/g4rich|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4drcalo|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4eiccalos|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4mrich|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4rich|osbornjd@ornl.gov

--- a/utils/rebuild/eic-packages.txt
+++ b/utils/rebuild/eic-packages.txt
@@ -89,13 +89,13 @@ fun4all_coresoftware/offline/packages/NodeDump|pinkenburg@bnl.gov
 # this is the convenience library which loads all libraries needed for reading
 # DSTs, please leave it at the end of the package list
 fun4all_coresoftware/simulation/g4simulation/g4dst|pinkenburg@bnl.gov
-fun4all_eicdetectors/g4beastmagnet|osbornjd@ornl.gov
-fun4all_eicdetectors/g4drcalo|osbornjd@ornl.gov
-fun4all_eicdetectors/g4eiccalos|osbornjd@ornl.gov
-fun4all_eicdetectors/g4jleic|osbornjd@ornl.gov
-fun4all_eicdetectors/g4lblvtx/source|osbornjd@ornl.gov
-fun4all_eicdetectors/g4mrich|osbornjd@ornl.gov
-fun4all_eicdetectors/g4rich|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4beastmagnet|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4drcalo|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4eiccalos|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4jleic|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4lblvtx/source|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4mrich|osbornjd@ornl.gov
+fun4all_eicdetectors/simulation/g4simulation/g4rich|osbornjd@ornl.gov
 eictoydetector/source|pinkenburg@bnl.gov
 fun4allgdmlimport/source|pinkenburg@bnl.gov
 fun4all_eic_qa/source|pinkenburg@bnl.gov


### PR DESCRIPTION
This PR adjusts the package files for the moving of the g4 sim packages in the fun4all_eicdetectors repo