### PR TITLE
Add new DD4hep version to play build, remove unused tpc-rs

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -74,7 +74,6 @@ my %externalRootPackages = (
     "KFParticle" => "KFParticle",
     "pythiaeRHIC" => "pythiaeRHIC",
     "sartre" => "sartre",
-    "tpc-rs" => "tpc-rs",
     "vgm" => "vgm"
     );
 my $rootversion = `root-config --version`;
@@ -278,6 +277,7 @@ if ($opt_version =~ /play/)
         $externalPackages{"boost"} = "boost-1.76.0";
         $externalPackages{"tbb"} = "tbb-2020.3";
 	$externalRootPackages{"HepMC3"} = "HepMC3-3.2.3";
+	$externalRootPackages{"DD4hep"} = "DD4hep-01-15";
     }
     else
     {


### PR DESCRIPTION
This PR makes a small mod - the new DD4hep version is used for the play build, tpc-rs is not used - it is not copied anymore