### PR TITLE
Multiple calib repos

### DIFF
--- a/utils/rebuild/ecce-repositories.txt
+++ b/utils/rebuild/ecce-repositories.txt
@@ -1,6 +1,7 @@
 acts
 calibrations
 coresoftware
+fun4all_eiccalibrations
 fun4all_eicdetectors
 online_distribution
 macros

--- a/utils/rebuild/eic-repositories.txt
+++ b/utils/rebuild/eic-repositories.txt
@@ -1,6 +1,7 @@
 calibrations
 eictoydetector
 fun4all_acts
+fun4all_eiccalibrations
 fun4all_coresoftware
 fun4all_eicdetectors
 fun4all_macros
@@ -8,3 +9,4 @@ fun4all_eic_qa
 fun4all_eicmacros
 fun4allgdmlimport
 online_distribution
+utilities


### PR DESCRIPTION
This PR enables the use of multiple calibrations repos (all repos with 'calibrations' in their name). The files are rsynced to their final destination. The problem of duplicate filenames is not addressed, last repo in the list wins - please be mindful of this