### PR TITLE
ECCE switches to independent calibrations repo

### DIFF
--- a/utils/rebuild/ecce-repositories.txt
+++ b/utils/rebuild/ecce-repositories.txt
@@ -1,7 +1,6 @@
 acts
 calibrations
 coresoftware
-fun4all_eiccalibrations
 fun4all_eicdetectors
 online_distribution
 macros


### PR DESCRIPTION
Similar to the macros repository, the ECCE calibration repository will switch to independent calibrations repository and use a single calibration repository model. 

This is part of the change as the ECCE simulation is rebuilt with June-2021 detector concept