### PR TITLE
suppress MISSING_MOVE_ASSIGNMENT for coverity

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1334,7 +1334,7 @@ sub install_coverity_reports
     if (defined $opt_covpasswd)
     {
         my $covdir =  sprintf("%s/covtmp",$workdir);
-        my $covanacmd = sprintf("cov-analyze  --disable DEADCODE --disable UNINIT_CTOR --disable FORWARD_NULL --disable UNUSED_VALUE --dir %s",$covdir);
+        my $covanacmd = sprintf("cov-analyze  --disable DEADCODE --disable UNINIT_CTOR --disable FORWARD_NULL --disable UNUSED_VALUE --disable MISSING_MOVE_ASSIGNMENT --dir %s",$covdir);
         print LOG "$covanacmd\n";
         open(F2,"$covanacmd 2>&1 |");
         while(my $line = <F2>)
@@ -1377,7 +1377,7 @@ sub install_coverity_reports
             if (-d $covdir)
             {
                 my $makehtml = 0;
-                my $covanacmd = sprintf("cov-analyze  --disable DEADCODE --disable UNINIT_CTOR --disable FORWARD_NULL --disable UNUSED_VALUE --disable CONSTANT_EXPRESSION_RESULT --dir %s",$covdir);
+                my $covanacmd = sprintf("cov-analyze  --disable DEADCODE --disable UNINIT_CTOR --disable FORWARD_NULL --disable UNUSED_VALUE --disable CONSTANT_EXPRESSION_RESULT --disable MISSING_MOVE_ASSIGNMENT --dir %s",$covdir);
                 open(F2,"$covanacmd 2>&1 |");
                 while(my $line = <F2>)
                 {


### PR DESCRIPTION
This PR suppresses the missing_move_assignemt - it is an optimization we can implement later. It generates quite some noise and I want to concentrate on real coding issues for the time being