### PR TITLE
Add LHAPDF-6.2.3 to the opt tar ball

### DIFF
--- a/utils/singularity/copy_to_target_area.pl
+++ b/utils/singularity/copy_to_target_area.pl
@@ -109,7 +109,8 @@ my @opt_dir_list = (sprintf("%s/bin",$core_basedir),
                     sprintf("%s/share",$core_basedir),
 		    sprintf("%s/stow",$core_basedir),
 		    sprintf("%s/lhapdf",$core_basedir),
-		    sprintf("%s/lhapdf-5.9.1",$core_basedir));
+		    sprintf("%s/lhapdf-5.9.1",$core_basedir),
+		    sprintf("%s/LHAPDF-6.2.3",$core_basedir));
 if ($opt_sysname =~ /gcc-8.3/)
 {
     push(@opt_dir_list,sprintf("%s/binutils",$core_basedir));


### PR DESCRIPTION
This PR adds LHAPDF-6.2.3 to the opt tarball. There are no pdfs yet, so this is a very small addition. One can leave it up to the experiments (sPHENIX, EIC, ECCE) which pdf sets to install in cvmfs or users can do this locally in their copy