### PR TITLE
Add xpload to external packages

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -68,7 +68,8 @@ my %externalPackages = (
     "rave" => "rave",
     "TAUOLA" => "TAUOLA",
     "tbb" => "tbb",
-    "Vc" => "Vc"
+    "Vc" => "Vc",
+    "xpload" => "xpload"
     );
 my $externalPackagesDir = "$OPT_SPHENIX";
 my %externalRootPackages = (


### PR DESCRIPTION
This PR adds xpload - our new shiny conditions DB interface - to the external packages which get copied over
https://github.com/BNLNPPS/xpload