### PR TITLE
add hdf5 to external packages

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -59,6 +59,7 @@ my %externalPackages = (
     "EvtGen" => "EvtGen",
     "fastjet" => "fastjet",
     "gsl" => "gsl",
+    "hdf5" => "hdf5",
     "HepMC" => "HepMC",
     "log4cpp" => "log4cpp",
     "PHOTOS" => "PHOTOS",


### PR DESCRIPTION
This PR adds hdf5 to our external packages. It's tested and working - so users do not have to tweak their paths to use it anymore.