### PR TITLE
succeed even if release times out (3 hours now), cvmfs can take a long time

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1075,15 +1075,16 @@ NORELEASEFILE:
     open(LOG, ">>$logfile");
     print LOG "$date initiating release, touching $releasefile\n";
     system("touch $releasefile");
-    my $n=70;
+    my $totalcycles=180;
+    my $n = $totalcycles;
     while($n > 0)
     {
-        sleep(30);
+        sleep(60);
         if (! -f $releasefile)
         {
             chomp (my $date = `date`);
-            my $cycles = 70-$n;
-            print LOG "$date build is released after $cycles cycles\n";
+            my $cycles = $totalcycles - $n;
+            print LOG "$date build is released after $cycles minutes\n";
             goto END;
         }
         chomp (my $date = `date`);
@@ -1091,8 +1092,8 @@ NORELEASEFILE:
         $n--;
     }
     chomp ($date = `date`);
-    print LOG "$date $releasefile still exists, giving up and failing build $n\n";
-    $buildSucceeded=0;
+    print LOG "$date $releasefile still exists, giving up waiting it will ultimately happen\n";
+    $buildSucceeded=1;
     goto END;
 
 }


### PR DESCRIPTION
This PR remedies a problem we have for ana or mdc builds. They release a top dir which can take a longtime to sync and they often run into the 30 minute timeout.
This PR extends the timeout for the cvmfs release to 3 hours. Even if the timeout is exceeded the build ends with success so the git tags are saved in the DB. We still have a protection in case the previous build is hanging.