### PR TITLE
use G4 10.06.p03 for g4test build

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -306,7 +306,7 @@ if ($opt_version =~ /play/)
 }
 elsif ($opt_version eq "g4test")
 {
-    $externalRootPackages{"DD4hep"} = "DD4hep-01-20-01_geant4-11.00.01";
+    $externalRootPackages{"DD4hep"} = "DD4hep-01-20-02_geant4-10.06.p03";
 }
 elsif ($opt_version =~ /old/) # build with previous versions 
 {


### PR DESCRIPTION
This PR now uses G4 10.06.p03 for the G4 version (down from G4 11)