### PR TITLE
print failure warning to trigger crontab email

### DIFF
--- a/utils/rebuild/rsync-build.pl
+++ b/utils/rebuild/rsync-build.pl
@@ -136,6 +136,7 @@ while (my $softlink = <F>)
 	if (! -e $slinklocation)
 	{
 	    print LOG "slinklocation $slinklocation not found\n";
+            print "Error in rsync-build.pl, slinklocation $slinklocation not found\n";
 	    exit(-1);
 	}
 	print LOG "creating $softlink -> $slinklocation\n";


### PR DESCRIPTION
The script now prints a warning to stdout on error so the cron will send an email. This script has been failing since May 5th and nobody noticed.