### PR TITLE
exclude cppcheck-2.6 from utils tar ball

### DIFF
--- a/utils/singularity/utils_no_tar.list
+++ b/utils/singularity/utils_no_tar.list
@@ -9,6 +9,7 @@ stow/cmake-3.20.1*
 stow/cppcheck-1.83*
 stow/cppcheck-2.2*
 stow/cppcheck-2.4*
+stow/cppcheck-2.6*
 stow/valgrind-3.13.0*
 stow/valgrind-3.15.0*
 stow/valgrind-3.16.1*


### PR DESCRIPTION
This PR drops cppcheck 2.6 from the utils tar ball