### PR TITLE
fix the scan build (make install for acts was missing)

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -770,7 +770,7 @@ if ($opt_stage < 3)
             $arg = "$covbuild make $insureCompileFlags $JOBS install ";
 	    if ( $opt_scanbuild)
 	    {
-		$arg = "$scanbuild make $insureCompileFlags $JOBS ";
+		$arg = "$scanbuild make $insureCompileFlags $JOBS install ";
 	    }
 	    else
 	    {


### PR DESCRIPTION
The make install for acts was missing for the scan build, fixed in this PR