### PR TITLE
Scan build clang 14

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -80,7 +80,6 @@ my %externalRootPackages = (
     "PHOTOS" => "PHOTOS",
     "pythia8" => "pythia8",
     "pythiaeRHIC" => "pythiaeRHIC",
-    "sartre" => "sartre",
     "TAUOLA" => "TAUOLA"
     );
 my $rootversion = `root-config --version`;
@@ -777,7 +776,9 @@ if ($opt_stage < 3)
 	    {
 		if ($opt_includecheck)
 		{
-		    $arg = "make -k CXX='include-what-you-use -I/opt/sphenix/utils/lib/clang/11.1.0/include ' "
+		    my $clangversion = `clang --version | head -1 | awk '{print \$3}'`;
+		    chomp $clangversion;
+		    $arg = sprintf("make -k CXX='include-what-you-use -I/opt/sphenix/utils/lib/clang/%s/include ' ",$clangversion);
 		}
 	    }
 	    print "acts install: running $arg\n";
@@ -1689,7 +1690,9 @@ sub CreateCmakeCommand
 	}
 	elsif ($opt_scanbuild)
 	{
-	    my $cxxcompiler = sprintf("/cvmfs/sphenix.sdcc.bnl.gov/%s/opt/sphenix/utils/stow/llvm-11.1.0/bin/../libexec/c++-analyzer",$opt_sysname);
+            my $clangversion = `clang --version | head -1 | awk '{print \$3}'`;
+            chomp $clangversion;
+	    my $cxxcompiler = sprintf("/cvmfs/sphenix.sdcc.bnl.gov/%s/opt/sphenix/utils/stow/llvm-%s/bin/../libexec/c++-analyzer",$opt_sysname, $clangversion);
 	    chomp $cxxcompiler;
 	    $cmakecmd = sprintf("%s -DCMAKE_CXX_COMPILER=%s",$cmakecmd,$cxxcompiler);
 	}

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -87,8 +87,6 @@ coresoftware/offline/packages/decayfinder|cdean@bnl.gov
 coresoftware/offline/packages/KFParticle_sPHENIX|cdean@bnl.gov
 # Offline tracking software
 coresoftware/offline/packages/trackreco|osbornjd@ornl.gov
-# PHTpcTracker needs libtrack_reco
-coresoftware/offline/packages/PHTpcTracker|pinkenburg@bnl.gov
 coresoftware/offline/packages/tpccalib|hugo.pereira-da-costa@cea.fr
 # Offline calorimeter software
 coresoftware/offline/packages/CaloReco|jhuang@bnl.gov


### PR DESCRIPTION
This PR makes the scan-build using clang 14 functional (the location had a hardcoded llvm-11 in the path). Remove copying of the obsolete sartre to OFFLINE_MAIN, remove PHTpcTracker from build (nothing linked against it)