### PR TITLE
remove now installed LHAPDF from opt tar ball, add llvm 14 to restow

### DIFF
--- a/utils/singularity/copy_to_target_area.pl
+++ b/utils/singularity/copy_to_target_area.pl
@@ -109,8 +109,7 @@ my @opt_dir_list = (sprintf("%s/bin",$core_basedir),
                     sprintf("%s/share",$core_basedir),
 		    sprintf("%s/stow",$core_basedir),
 		    sprintf("%s/lhapdf",$core_basedir),
-		    sprintf("%s/lhapdf-5.9.1",$core_basedir),
-		    sprintf("%s/LHAPDF-6.2.3",$core_basedir));
+		    sprintf("%s/lhapdf-5.9.1",$core_basedir));
 if ($opt_sysname =~ /gcc-8.3/)
 {
     push(@opt_dir_list,sprintf("%s/binutils",$core_basedir));

--- a/utils/singularity/utils_restow.list
+++ b/utils/singularity/utils_restow.list
@@ -1,2 +1,4 @@
 include-what-you-use-11.1.0
 llvm-11.1.0
+include-what-you-use-14.0.6
+llvm-14.0.6


### PR DESCRIPTION
This PR is an update to deal with the gcc 12.1.0 builds