### PR TITLE
set maximum builds to 10 before roll over

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -209,6 +209,10 @@ my $numcores  = do { local @ARGV='/proc/cpuinfo'; grep /^processor\s+:/, <>;};
 my $JOBS = sprintf("-l %d -j %d", $numcores, $numcores);
 
 my $MAXDEPTH = ($opt_version =~ m/pro/ || $opt_version =~ /ana/ || $opt_version =~ /mdc/ || $opt_version =~ /tracking/) ? 9999999 : 4;
+if ($opt_version =~ m/new/ && !$opt_insure)
+{
+    $MAXDEPTH = 10;
+}
 $opt_version .= '+insure' if $opt_insure;
 # number of parallel builds with insure
 if ($numcores > 25) {$numcores=25;} # we have 50 insure licenses, only use 1/2 maximum


### PR DESCRIPTION
This PR sets the number of new builds to 10 before they roll over