### PR TITLE
remove xpload and db_file_accessor

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -67,8 +67,7 @@ my %externalPackages = (
     "rave" => "rave",
     "starlight" => "starlight",
     "tbb" => "tbb",
-    "Vc" => "Vc",
-    "xpload" => "xpload"
+    "Vc" => "Vc"
     );
 my $externalPackagesDir = "$OPT_SPHENIX";
 my %externalRootPackages = (

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -48,8 +48,6 @@ coresoftware/offline/packages/trackbase|afrawley@fsu.edu
 coresoftware/offline/packages/trackbase_historic|afrawley@fsu.edu
 coresoftware/offline/packages/rawtodst|afrawley@fsu.edu
 coresoftware/simulation/g4simulation/g4tracking|0ds.johnny@gmail.com
-#dbfile_accessor_calo needs CaloBase
-coresoftware/calibrations/calorimeter/dbfile_accessor_calo|frantz@ohio.edu
 # tracking needs g4 detectors for geometry classes
 # mvtx needs trackbase, tracking also needs trackbase_historic for now
 coresoftware/offline/packages/mvtx|ycmorales@rcf.rhic.bnl.gov


### PR DESCRIPTION
Xpload is obsolete - remove from copying to offline, db_file_accessor is replaced by CDBTTree