### PR TITLE
add mbd to be able to rename bbc -> mbd

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -43,10 +43,11 @@ coresoftware/simulation/g4simulation/g4decayer|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4gdml|jhuang@bnl.gov
 coresoftware/simulation/g4simulation/g4main|pinkenburg@bnl.gov
 coresoftware/offline/packages/CaloBase|jhuang@bnl.gov
-# g4detectors/g4ihcal/g4ohcal and offline/packages/bbc need calo_io
+# g4detectors/g4ihcal/g4ohcal and offline/packages/mbd need calo_io
 coresoftware/simulation/g4simulation/g4detectors|pinkenburg@bnl.gov
 coresoftware/simulation/g4simulation/g4ihcal|msar@gsu.edu
 coresoftware/simulation/g4simulation/g4ohcal|msar@gsu.edu
+coresoftware/offline/packages/mbd|chiu@bnl.gov
 coresoftware/offline/packages/bbc|chiu@bnl.gov
 coresoftware/offline/packages/trackbase|afrawley@fsu.edu
 coresoftware/offline/packages/trackbase_historic|afrawley@fsu.edu


### PR DESCRIPTION
This PR adds the mbd to prepare for a rename of bbc -> mbd. It does not matter if a package does not exist, the build will just skip it (and complain a bit)