### PR TITLE
fill repo tags hash before writing info file

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1012,6 +1012,21 @@ INSTALLONLY:
 
 $buildSucceeded = 1;
 
+# save the latest commit id of the checkouts
+my %repotags = ();
+foreach my $repo (@gitrepos)
+{
+    $repodir = sprintf("%s/%s",$sourceDir,$repo);
+    if (-d $repodir)
+    {
+        chdir $repodir;
+        $fullrepo = sprintf("%s/%s.git",$opt_repoowner, $repo);
+        my $gittag = `git show | head -1 | awk '{print \$2}'`;
+        chomp $gittag;
+        $repotags{$fullrepo} = $gittag;
+    }
+}
+
 # creating and writing rebuild.info
 $rebuildInfo=$OFFLINE_MAIN.'/rebuild.info';
 $sysInfo=`uname -a`;
@@ -1174,20 +1189,6 @@ END:{
   $buildSucceeded==0 && ($buildStatus='busted', POSIX::_exit(-1), last END);
 }
 
-# save the latest commit id of the checkouts
-my %repotags = ();
-foreach my $repo (@gitrepos)
-{
-    $repodir = sprintf("%s/%s",$sourceDir,$repo);
-    if (-d $repodir)
-    {
-        chdir $repodir;
-        $fullrepo = sprintf("%s/%s.git",$opt_repoowner, $repo);
-        my $gittag = `git show | head -1 | awk '{print \$2}'`;
-        chomp $gittag;
-        $repotags{$fullrepo} = $gittag;
-    }
-}
 
 if ($opt_tinderbox) 
 {


### PR DESCRIPTION
The repotags hash map was only filled after the rebuild.info was written, now fill repotags before writing rebuild.info