### PR TITLE
Move QA utility order up to allow use of QA stuff everywhere in Fun4All

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -14,6 +14,8 @@ coresoftware/offline/framework/frog|pinkenburg@bnl.gov
 coresoftware/offline/framework/ffaobjects|pinkenburg@bnl.gov
 coresoftware/offline/framework/ffarawobjects|pinkenburg@bnl.gov
 coresoftware/offline/framework/fun4all|pinkenburg@bnl.gov
+# qa utils for data based qa modules
+coresoftware/offline/packages/QAUtils|josborn1@bnl.gov
 coresoftware/offline/framework/fun4allraw|pinkenburg@bnl.gov
 coresoftware/offline/framework/ffarawmodules|pinkenburg@bnl.gov
 coresoftware/calibrations/framework/oncal|pinkenburg@bnl.gov
@@ -60,8 +62,6 @@ coresoftware/offline/packages/mbd|chiu@bnl.gov
 #coresoftware/offline/packages/rawtodst|afrawley@fsu.edu
 coresoftware/simulation/g4simulation/g4tracking|0ds.johnny@gmail.com
 # tracking needs g4 detectors for geometry classes
-# qa utils for data based qa modules
-coresoftware/offline/packages/QAUtils|josborn1@bnl.gov
 # mvtx needs trackbase, tracking also needs trackbase_historic for now
 coresoftware/offline/packages/mvtx|ycmorales@rcf.rhic.bnl.gov
 coresoftware/offline/packages/intt|afrawley@fsu.edu


### PR DESCRIPTION
Move QA utility order up to allow use of QA stuff everywhere in Fun4All

I am working on TPC code in `fun4allraw`, and realized that the internal workings of `fun4allraw` could use some formal QA there, e.g. QA histogram built as events are unpacked and assembled together, before they hit the DST. This PR will allow such wide use of QA, as long as it is using Fun4All framework (and therefore built after `fun4all` lib). 

