### PR TITLE
add -DEVTGEN_HEPMC3 to clang-tidy flags

### DIFF
--- a/jenkins/built-test/clang-tidy.sh
+++ b/jenkins/built-test/clang-tidy.sh
@@ -36,7 +36,7 @@ if test -f clang-tidy-result.txt; then
 fi
 
 shopt -s globstar
-clang-tidy ./coresoftware/**/*.cc ./coresoftware/**/*.cpp -- -Wall -Werror -Wshadow -std=c++17 -Wno-dangling -isystem$OFFLINE_MAIN/include -isystem$ROOTSYS/include -isystem$G4_MAIN/include -isystem$G4_MAIN/include/Geant4  -isystem$OPT_SPHENIX/include -DHomogeneousField -DRAVE -DRaveDllExport= > clang-tidy-result.txt
+clang-tidy ./coresoftware/**/*.cc ./coresoftware/**/*.cpp -- -Wall -Werror -Wshadow -std=c++17 -Wno-dangling -isystem$OFFLINE_MAIN/include -isystem$ROOTSYS/include -isystem$G4_MAIN/include -isystem$G4_MAIN/include/Geant4  -isystem$OPT_SPHENIX/include -DHomogeneousField -DEVTGEN_HEPMC3 -DRAVE -DRaveDllExport= > clang-tidy-result.txt
 
 ls -hvl $PWD/clang-tidy-result.txt
 wc -l clang-tidy-result.txt


### PR DESCRIPTION
This PR takes care of the clang-tidy errors from g4decayer.  -DEVTGEN_HEPMC3 is set in the Makefile.am to select EvtGen's HepMC3 implementation. clang-tidy doesn't read the Makefile.am so it ran without this define and kept generating rather severe justified error message