### PR TITLE
new odbc driver needs different date format

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -1731,7 +1731,8 @@ CONNECTAGAIN2:
     my $insertbuild = $dbh->prepare("insert into buildtags (build, date, unixdate, reponame, tag) values (?, ?, ?, ?, ?)");
     my $unixdate = `date +%s`;
     chomp $unixdate;
-    my $humandate = `date`;
+    my $humandate = `date '+%F %T'`;
+    chomp $humandate;
 
     foreach my $key (keys %repotags)
     {


### PR DESCRIPTION
I updated the psqlodbc driver yesterday, it seems to reject the unix timestamp used for the date. This PR now uses a time stamp which works with the new driver