### PR TITLE
move caloTreeGen to packages

### DIFF
--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -126,6 +126,8 @@ prototype/offline/packages/Prototype4|jhuang@bnl.gov
 coresoftware/offline/packages/ResonanceJetTagging|antonio.sphenix@gmail.com
 #DST Skimmers
 coresoftware/offline/packages/Skimmers/Jets|sli7@bnl.gov
+# trees for users to get started
+coresoftware/offline/packages/caloTreeGen|ahodges4@illinois.edu
 # QA modules that use both simulation and offline libs
 #coresoftware/offline/QA/modules|jhuang@bnl.gov
 coresoftware/offline/QA/Global|josborn1@bnl.gov
@@ -140,7 +142,6 @@ coresoftware/offline/QA/Trigger|Daniel.Lis@colorado.edu
 coresoftware/offline/QA/Tpc|josborn1@bnl.gov
 coresoftware/offline/QA/Jet|vbailey13@gsu.edu
 coresoftware/offline/QA/KFParticle|cdean@bnl.gov
-coresoftware/offline/QA/caloTreeGen|ahodges4@illinois.edu
 # TPC hit and track prep for event display
 coresoftware/offline/packages/TPCHitTrackDisplay|rosstom@g.ucla.edu
 # calibrations


### PR DESCRIPTION
caloTreeGen was not build bc the wrong location in packages.txt. Moved it to offline/packages which is more logical better place