### PR TITLE
add --suppress=syntaxError to cppcheck args to remove perceived syntax errors

### DIFF
--- a/jenkins/built-test/cpp-check.sh
+++ b/jenkins/built-test/cpp-check.sh
@@ -14,7 +14,7 @@ endif
 # cppcheck -q --enable=warning --enable=style --enable=performance --platform=unix64 --inconclusive --xml --xml-version=2 -j16 --std=c++11 ./coresoftware > & cppcheck.xml
 # cppcheck -q --enable=warning --enable=performance --platform=unix64 --inconclusive --xml --xml-version=2 -j 10 --std=c++11 ./coresoftware > & cppcheck-result.xml
 # cppcheck -q --inline-suppr  --enable=warning --enable=performance --platform=unix64 --inconclusive --xml --xml-version=2 -j 10 --std=c++20 ./coresoftware > & cppcheck-result.xml
-cppcheck -q --inline-suppr  --enable=warning --enable=performance --platform=unix64 --inconclusive --xml --xml-version=2 -j 10 --std=c++20 --check-level=exhaustive ./coresoftware > & cppcheck-result.xml
+cppcheck -q --inline-suppr  --enable=warning --enable=performance --platform=unix64 --inconclusive --xml --xml-version=2 -j 10 --std=c++20 --check-level=exhaustive --suppress=syntaxError ./coresoftware > & cppcheck-result.xml
 
 
 ls -hvl $PWD/cppcheck-result.xml


### PR DESCRIPTION
nanoflann.hpp generates a syntax error warning which can't be fixed. using --suppress=syntaxError in the cmd line suppresses those errors