### PR TITLE
Add herwig

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -49,7 +49,6 @@ umask 002;
 
 my %externalPackages = (
     "boost" => "boost",
-    "bzip2" => "bzip2",
     "CGAL" => "CGAL",
     "CLHEP" => "CLHEP",
     "Eigen" => "Eigen",
@@ -77,7 +76,6 @@ my %externalRootPackages = (
     "KFParticle" => "KFParticle",
     "PHOTOS" => "PHOTOS",
     "pythia8" => "pythia8",
-    "pythiaeRHIC" => "pythiaeRHIC",
     "TAUOLA" => "TAUOLA"
     );
 my $rootversion = `root-config --version`;

--- a/utils/rebuild/packages.txt
+++ b/utils/rebuild/packages.txt
@@ -34,6 +34,8 @@ coresoftware/generators/HIJINGFlipAfterburner|sl4859@columbia.edu
 coresoftware/generators/ReactionPlaneAfterburner|sl4859@columbia.edu
 #PHPythia8 needs phhepmc
 coresoftware/generators/PHPythia8|dvp@bnl.gov
+#Herwig needs phhepmc
+coresoftware/generators/Herwig|sgrossberndt@gradcenter.cuny.edu
 # ffamodules need sphenixnpc
 coresoftware/offline/database/sphenixnpc|pinkenburg@bnl.gov
 # we want generator values in the event header


### PR DESCRIPTION
This adds the Herwig jet trigger package. Cleanup: remove installation of bzip2 (now part of alma9) and pythiaeRhic (does not build anymore)