### PR TITLE
increase number of new builds to 20

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -231,7 +231,7 @@ my $JOBS = sprintf("-l %d -j %d", $numcores, $numcores);
 my $MAXDEPTH = ($opt_version =~ m/pro/ || $opt_version =~ /ana/ || $opt_version =~ /mdc/ || $opt_version =~ /tracking/) ? 9999999 : 4;
 if ($opt_version =~ m/new/ && !$opt_insure)
 {
-    $MAXDEPTH = 10;
+    $MAXDEPTH = 20;
 }
 $opt_version .= '+insure' if $opt_insure;
 # number of parallel builds with insure


### PR DESCRIPTION
There is a danger for long running condor jobs (10 days right now) to run beyond the rollover of the new builds (10 days). This PR increases the number of builds before rolling over to 20