### PR TITLE
fix: opt repo owner bug

### DIFF
--- a/utils/rebuild/build.pl
+++ b/utils/rebuild/build.pl
@@ -128,7 +128,7 @@ if (! defined $opt_actsrepoowner)
     $opt_actsrepoowner = $opt_repoowner;
 }
 
-if (! defined $opt_coreowner)
+if (defined $opt_repoowner)
 {
     $opt_coreowner  = $opt_repoowner;
 }


### PR DESCRIPTION
I think a bug was introduced into our build script somehow, which went unnoticed because it only matters if you set `--repoowner` which likely doesn't happen often. When trying to build Acts locally I noticed the coresoftware repo owner gets overriden by this if statement. `$opt_coreowner` is defined as a default value `sPHENIX-Collaboration` at the top of the script, so this if statement never gets triggered and thus only the coresoftware repo owner is set to the default value sPHENIX-Collaboration. This PR fixes it to check if `opt_repoowner` is set, and if it is then the `opt_coreowner` string is set