### PR TITLE
add -I./ to allow local includes with <>

### DIFF
--- a/jenkins/built-test/clang-tidy-macros.sh
+++ b/jenkins/built-test/clang-tidy-macros.sh
@@ -61,6 +61,7 @@ mkdir -p "$OUTDIR"
 # (same flags you were passing after the --)
 COMPILE_ARGS_STR="
   -Wall -Werror -Wshadow -std=c++20 -Wno-dangling
+  -I./
   -isystem$WORKSPACE/macros/common
   -isystem$OFFLINE_MAIN/include
   -isystem$ROOTSYS/include

--- a/jenkins/built-test/clang-tidy-prodmacros.sh
+++ b/jenkins/built-test/clang-tidy-prodmacros.sh
@@ -61,6 +61,7 @@ mkdir -p "$OUTDIR"
 # (same flags you were passing after the --)
 COMPILE_ARGS_STR="
   -Wall -Werror -Wshadow -std=c++20 -Wno-dangling
+  -I./
   -isystem$OFFLINE_MAIN/include
   -isystem$ROOTSYS/include
   -isystem$G4_MAIN/include


### PR DESCRIPTION
This adds -I./ to the clang-tidy include path for macro checks which allows to use local includes with #include <>. This should get rid of the need to use "" for local includes which is a problem for our overall use of included macros